### PR TITLE
Overhead schedule verification and PA clip injection

### DIFF
--- a/TOURNAMENT_RUNBOOK.md
+++ b/TOURNAMENT_RUNBOOK.md
@@ -152,6 +152,31 @@ uses ffmpeg silencedetect to avoid talking over the countdown). Default clip: Da
 Clip presets: `--clip-preset three_minutes_no_blocking` (default), `no_blocking`, `three_minutes_remaining`.  
 Requires the GarageBand project under `--band-dir` (default: `~/Downloads/15 min round - foam NS 8.5 (no time limit on NB).band`).
 
+**Inject Start buzzer at play start** (after no-blocking; play-start only — not play-end or boundary buzzers):
+
+Overlays the GarageBand **Start buzzer** tone immediately after each round's "Players line up / here we go" phrase (same file duration; uses transcript phrase-end detection). Run on the no-blocking wav so prior overlays stay intact.
+
+```bash
+# Preview insertion points (use by-round report for the no-blocking wav)
+./src/bash/inject_start_buzzer.sh \
+  --wav "/path/to/BDL Throwdown 5 Full Timeline_with_no_blocking.wav" \
+  --report "/path/to/BDL Throwdown 5 Full Timeline_with_no_blocking_overhead_by_round_report.json" \
+  --transcript "/path/to/BDL Throwdown 5 Full Timeline.wav.transcript.json" \
+  --dry-run
+
+# Write {wav_stem}_with_no_blocking_and_start_buzzer.wav
+./src/bash/inject_start_buzzer.sh \
+  --wav "/path/to/BDL Throwdown 5 Full Timeline_with_no_blocking.wav" \
+  --report "/path/to/BDL Throwdown 5 Full Timeline_with_no_blocking_overhead_by_round_report.json" \
+  --transcript "/path/to/BDL Throwdown 5 Full Timeline.wav.transcript.json" \
+  --verify
+
+# Fail if insert would overlap non-play_start speech
+  --require-phrase-clear
+```
+
+Default clip: `Start buzzer` from the same GarageBand project (`--band-dir`). Writes `{output}.injections.json` with `injection_type: start_buzzer` and a reference to the upstream no-blocking sidecar.
+
 The script writes `{wav_stem}_overhead_verification_report.json` next to the `.wav`. Exit code 0 when match rate ≥ 80% and max drift ≤ 120s.
 
 **Lunch break:** skip the gap when PA was silent:
@@ -278,6 +303,7 @@ Options:
 | `validate_tournament_setup.sh` | Test pipeline on sample Week2 footage |
 | `verify_overhead_schedule.sh` | Verify overhead .wav vs schedule JSONL |
 | `inject_no_blocking.sh` | Insert no-blocking PA clips into overhead .wav using by-round report |
+| `inject_start_buzzer.sh` | Insert Start buzzer at play start into overhead .wav (after no-blocking) |
 | `excel_schedule_to_jsonl.py` | Excel → per-court `games.jsonl` |
 
 Lower-level scripts (called automatically): `combine_gopro_videos.sh`, `split_multi_source_videos.sh`.

--- a/TOURNAMENT_RUNBOOK.md
+++ b/TOURNAMENT_RUNBOOK.md
@@ -127,6 +127,25 @@ Each speech item in the JSON report includes:
 
 The report root includes `audio_structure` with notes on no-blocking, the two-countdown-per-round pattern, and verification scope. Each round includes a `structure` summary with role counts.
 
+**Inject no-blocking announcements** (when clips exist in GarageBand but not in the export):
+
+```bash
+# Preview insertion points (from by-round report)
+./src/bash/inject_no_blocking.sh \
+  --wav "/path/to/BDL Throwdown 5 Full Timeline.wav" \
+  --report "/path/to/BDL Throwdown 5 Full Timeline_overhead_by_round_report.json" \
+  --dry-run
+
+# Write {wav_stem}_with_no_blocking.wav (default clip: Dance Vocal#31)
+./src/bash/inject_no_blocking.sh \
+  --wav "/path/to/BDL Throwdown 5 Full Timeline.wav" \
+  --report "/path/to/BDL Throwdown 5 Full Timeline_overhead_by_round_report.json" \
+  --verify
+```
+
+Clip presets: `--clip-preset three_minutes_no_blocking` (default), `no_blocking`, `three_minutes_remaining`.  
+Requires the GarageBand project under `--band-dir` (default: `~/Downloads/15 min round - foam NS 8.5 (no time limit on NB).band`).
+
 The script writes `{wav_stem}_overhead_verification_report.json` next to the `.wav`. Exit code 0 when match rate ≥ 80% and max drift ≤ 120s.
 
 **Lunch break:** skip the gap when PA was silent:
@@ -252,6 +271,7 @@ Options:
 | `collect_deliverables.sh` | Symlink/copy all matchups to `deliverables/` |
 | `validate_tournament_setup.sh` | Test pipeline on sample Week2 footage |
 | `verify_overhead_schedule.sh` | Verify overhead .wav vs schedule JSONL |
+| `inject_no_blocking.sh` | Insert no-blocking PA clips into overhead .wav using by-round report |
 | `excel_schedule_to_jsonl.py` | Excel → per-court `games.jsonl` |
 
 Lower-level scripts (called automatically): `combine_gopro_videos.sh`, `split_multi_source_videos.sh`.

--- a/TOURNAMENT_RUNBOOK.md
+++ b/TOURNAMENT_RUNBOOK.md
@@ -123,6 +123,9 @@ Each speech item in the JSON report includes:
 - `offset` / `offset_seconds` — seconds from that round's inferred anchor (e.g. `+4:00`)
 - `wall_time` — tournament wall clock (from `--wav-start-time`)
 - `text` — exact Whisper phrase
+- `role` / `role_label` — interpreted PA role (e.g. `countdown_play_end`, `countdown_round_boundary`, `court_call_court1`)
+
+The report root includes `audio_structure` with notes on no-blocking, the two-countdown-per-round pattern, and verification scope. Each round includes a `structure` summary with role counts.
 
 The script writes `{wav_stem}_overhead_verification_report.json` next to the `.wav`. Exit code 0 when match rate ≥ 80% and max drift ≤ 120s.
 

--- a/TOURNAMENT_RUNBOOK.md
+++ b/TOURNAMENT_RUNBOOK.md
@@ -88,6 +88,42 @@ Scrub the `.wav` at offset `0:00` — you should hear the first round's start an
   --tolerance 90
 ```
 
+**Per-round check** (recommended — anchors each round independently, re-transcribes bundled Whisper segments with 8s sub-chunks):
+
+```bash
+./src/bash/verify_overhead_schedule.sh \
+  --wav "/Users/jessicasartin/Downloads/BDL Throwdown 5 Full Timeline.wav" \
+  --schedule-dir src/output/June2026Tournament/schedule/generated \
+  --date 2026-06-20 \
+  --courts 2,3,4 \
+  --wav-start-time 09:00 \
+  --by-round
+
+# Detail for one round:
+  --by-round --round 3
+
+# Skip slow refinement (uses full-file transcript only):
+  --by-round --no-refine-bundled
+```
+
+Refined bundled segments are cached beside the transcript as `{wav}.transcript.refined.json`.
+
+**Output files** (written beside the `.wav`):
+
+| File | Contents |
+|------|----------|
+| `{wav_stem}_overhead_by_round_report.json` | Full structured report: match results, per-round speech with wav timestamp + slot offset |
+| `{wav_stem}_overhead_by_round_phrases.txt` | Human-readable phrase list (WAV time, offset from round anchor, wall time, text) |
+| `{wav_stem}.transcript.json` | Cached full-file Whisper transcript |
+| `{wav_stem}.transcript.refined.json` | Cached bundled-segment refinements |
+
+Each speech item in the JSON report includes:
+
+- `wav_timestamp` — position in the `.wav` (e.g. `04:00:48`)
+- `offset` / `offset_seconds` — seconds from that round's inferred anchor (e.g. `+4:00`)
+- `wall_time` — tournament wall clock (from `--wav-start-time`)
+- `text` — exact Whisper phrase
+
 The script writes `{wav_stem}_overhead_verification_report.json` next to the `.wav`. Exit code 0 when match rate ≥ 80% and max drift ≤ 120s.
 
 **Lunch break:** skip the gap when PA was silent:

--- a/TOURNAMENT_RUNBOOK.md
+++ b/TOURNAMENT_RUNBOOK.md
@@ -129,6 +129,9 @@ The report root includes `audio_structure` with notes on no-blocking, the two-co
 
 **Inject no-blocking announcements** (when clips exist in GarageBand but not in the export):
 
+Overlays the clip a few seconds into the post-buzzer silent window (same file duration;
+uses ffmpeg silencedetect to avoid talking over the countdown). Default clip: Dance Vocal#31.
+
 ```bash
 # Preview insertion points (from by-round report)
 ./src/bash/inject_no_blocking.sh \
@@ -136,11 +139,14 @@ The report root includes `audio_structure` with notes on no-blocking, the two-co
   --report "/path/to/BDL Throwdown 5 Full Timeline_overhead_by_round_report.json" \
   --dry-run
 
-# Write {wav_stem}_with_no_blocking.wav (default clip: Dance Vocal#31)
+# Write {wav_stem}_with_no_blocking.wav
 ./src/bash/inject_no_blocking.sh \
   --wav "/path/to/BDL Throwdown 5 Full Timeline.wav" \
   --report "/path/to/BDL Throwdown 5 Full Timeline_overhead_by_round_report.json" \
   --verify
+
+# Fail if silencedetect cannot confirm silence at an insert point
+  --require-silence-verify
 ```
 
 Clip presets: `--clip-preset three_minutes_no_blocking` (default), `no_blocking`, `three_minutes_remaining`.  

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements-transcribe.txt
+pytest>=8.0.0

--- a/requirements-transcribe.txt
+++ b/requirements-transcribe.txt
@@ -1,0 +1,2 @@
+faster-whisper>=1.1.0
+rapidfuzz>=3.0.0

--- a/src/bash/combine_week_courts.sh
+++ b/src/bash/combine_week_courts.sh
@@ -31,10 +31,18 @@ while [ $# -gt 0 ]; do
       shift
       ;;
     --court)
+      if [ -z "$2" ]; then
+        echo "Error: --court requires a court number or name (e.g. 1 or Court1)"
+        exit 1
+      fi
       COURT_FILTER="$2"
       shift 2
       ;;
     --title-prefix)
+      if [ -z "$2" ]; then
+        echo "Error: --title-prefix requires a value"
+        exit 1
+      fi
       TITLE_PREFIX="$2"
       shift 2
       ;;
@@ -53,12 +61,14 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "$week_dir" ]; then
-  echo "Usage: $0 <week_directory> [output_directory] [--title-prefix \"...\"] [--dry-run]"
+  echo "Usage: $0 <week_directory> [output_directory] [options]"
   echo ""
   echo "  <week_directory>: Directory containing court1/Court1, court2/Court2, ... subfolders"
   echo "  [output_directory]: Where merged videos are written (default: <week_directory>/merged_videos)"
   echo "  --title-prefix: Upload title prefix, e.g. \"BDL Season 7: Summer Remix\""
   echo "                  Output: \"<title_prefix>: Week 3 Court 1.MP4\""
+  echo "  --court N: Only merge the named court (e.g. 1, Court1)"
+  echo "  --allow-partial: Merge available clips even if some are still transferring"
   echo "  --dry-run: List clips and planned outputs without merging"
   echo ""
   echo "Expected structure:"
@@ -121,19 +131,43 @@ abs_path() {
   echo "$(cd "$dir" && pwd)/$base"
 }
 
-# GOPR, then GP segments, then GX segments (GoPro chapter order)
+file_size_bytes() {
+  local file="$1"
+  local size
+
+  size="$(stat -f%z "$file" 2>/dev/null || stat -c%s "$file" 2>/dev/null || echo 0)"
+  echo "$size"
+}
+
+# Group clips by GoPro session ID (four-digit suffix), then GOPR -> GP -> GX per session.
 list_gopro_files() {
   local court_dir="$1"
-  find "$court_dir" -maxdepth 1 -type f \( -iname 'GOPR*.MP4' -o -iname 'GOPR*.mp4' \) 2>/dev/null | sort
-  find "$court_dir" -maxdepth 1 -type f \( -iname 'GP[0-9]*.MP4' -o -iname 'GP[0-9]*.mp4' \) ! -iname 'GOPR*' 2>/dev/null | sort
-  find "$court_dir" -maxdepth 1 -type f \( -iname 'GX*.MP4' -o -iname 'GX*.mp4' \) 2>/dev/null | sort
+  local gx_ids gp_ids gopr_ids all_ids video_id gopr_files gp_files gx_files files
+
+  gx_ids=$(find "$court_dir" -maxdepth 1 -type f \( -iname 'GX??????.MP4' -o -iname 'GX??????.mp4' \) 2>/dev/null \
+    | sed -E 's/.*GX[0-9]{2}([0-9]{4})\.[^/]+$/\1/I' | sort -u)
+  gp_ids=$(find "$court_dir" -maxdepth 1 -type f \( -iname 'GP??????.MP4' -o -iname 'GP??????.mp4' \) 2>/dev/null \
+    | sed -E 's/.*GP[0-9]{2}([0-9]{4})\.[^/]+$/\1/I' | sort -u)
+  gopr_ids=$(find "$court_dir" -maxdepth 1 -type f \( -iname 'GOPR????.MP4' -o -iname 'GOPR????.mp4' \) 2>/dev/null \
+    | sed -E 's/.*GOPR([0-9]{4})\.[^/]+$/\1/I' | sort -u)
+  all_ids=$(printf '%s\n%s\n%s\n' "$gx_ids" "$gp_ids" "$gopr_ids" | grep -v '^$' | sort -u)
+
+  for video_id in $all_ids; do
+    gopr_files=$(find "$court_dir" -maxdepth 1 -type f \( -iname "GOPR${video_id}.MP4" -o -iname "GOPR${video_id}.mp4" \) 2>/dev/null | sort)
+    gp_files=$(find "$court_dir" -maxdepth 1 -type f \( -iname "GP??${video_id}.MP4" -o -iname "GP??${video_id}.mp4" \) 2>/dev/null | sort)
+    gx_files=$(find "$court_dir" -maxdepth 1 -type f \( -iname "GX??${video_id}.MP4" -o -iname "GX??${video_id}.mp4" \) 2>/dev/null | sort)
+    files=$(printf '%s\n%s\n%s\n' "$gopr_files" "$gp_files" "$gx_files" | grep -v '^$')
+    if [ -n "$files" ]; then
+      printf '%s\n' "$files"
+    fi
+  done
 }
 
 is_valid_video() {
   local file="$1"
   local size
 
-  size="$(stat -f%z "$file" 2>/dev/null || echo 0)"
+  size="$(file_size_bytes "$file")"
   if [ "$size" -lt 1048576 ]; then
     return 1
   fi
@@ -221,6 +255,7 @@ fi
 echo ""
 
 court_count=0
+merged_count=0
 for court_dir in $(find_court_dirs); do
   [ -d "$court_dir" ] || continue
   court_count=$((court_count + 1))
@@ -282,6 +317,7 @@ for court_dir in $(find_court_dirs); do
     echo "Combining $file_count clips -> $output_file"
     ffmpeg -y -f concat -safe 0 -i "$temp_file" -c copy "$output_file"
   fi
+  merged_count=$((merged_count + 1))
   rm -f "$temp_file"
 
   if command -v ffprobe >/dev/null 2>&1; then
@@ -306,6 +342,11 @@ fi
 if [ "$DRY_RUN" = true ]; then
   echo "=== Dry-run complete ==="
   exit 0
+fi
+
+if [ "$merged_count" -eq 0 ]; then
+  echo "Error: No merged videos were written (all courts skipped or had no complete clips)"
+  exit 1
 fi
 
 echo "=== Complete ==="

--- a/src/bash/inject_no_blocking.sh
+++ b/src/bash/inject_no_blocking.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Insert no-blocking PA clips into a venue-wide overhead .wav after play-end countdowns.
+# Usage: inject_no_blocking.sh --wav PATH --report PATH [options...]
+
+set -e
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+python_script="$repo_root/src/scripts/inject_no_blocking.py"
+
+if [ ! -f "$python_script" ]; then
+  echo "Error: inject_no_blocking.py not found at $python_script"
+  exit 1
+fi
+
+for cmd in ffprobe ffmpeg python3; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd not installed."
+    exit 1
+  fi
+done
+
+PYTHON=""
+if [ -x "$repo_root/.venv/bin/python" ]; then
+  PYTHON="$repo_root/.venv/bin/python"
+else
+  PYTHON="python3"
+fi
+
+exec "$PYTHON" "$python_script" "$@"

--- a/src/bash/inject_start_buzzer.sh
+++ b/src/bash/inject_start_buzzer.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Insert Start buzzer clips into a venue-wide overhead .wav at each round's play start.
+# Usage: inject_start_buzzer.sh --wav PATH --report PATH [options...]
+
+set -e
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+python_script="$repo_root/src/scripts/inject_start_buzzer.py"
+
+if [ ! -f "$python_script" ]; then
+  echo "Error: inject_start_buzzer.py not found at $python_script"
+  exit 1
+fi
+
+for cmd in ffprobe ffmpeg python3; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd not installed."
+    exit 1
+  fi
+done
+
+PYTHON=""
+if [ -x "$repo_root/.venv/bin/python" ]; then
+  PYTHON="$repo_root/.venv/bin/python"
+else
+  PYTHON="python3"
+fi
+
+exec "$PYTHON" "$python_script" "$@"

--- a/src/bash/verify_overhead_schedule.sh
+++ b/src/bash/verify_overhead_schedule.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Verify venue-wide overhead .wav announcements against schedule JSONL files.
+# Usage: verify_overhead_schedule.sh --wav PATH --schedule-dir DIR --date YYYY-MM-DD [options...]
+
+set -e
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+python_script="$repo_root/src/scripts/verify_overhead_schedule.py"
+
+if [ ! -f "$python_script" ]; then
+  echo "Error: verify_overhead_schedule.py not found at $python_script"
+  exit 1
+fi
+
+for cmd in ffprobe python3; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd not installed."
+    exit 1
+  fi
+done
+
+PYTHON=""
+if [ -x "$repo_root/.venv/bin/python" ]; then
+  PYTHON="$repo_root/.venv/bin/python"
+else
+  PYTHON="python3"
+fi
+
+timeline_only=false
+for arg in "$@"; do
+  if [ "$arg" = "--timeline-only" ]; then
+    timeline_only=true
+    break
+  fi
+done
+
+if [ "$timeline_only" = false ]; then
+  if ! "$PYTHON" -c "import rapidfuzz" 2>/dev/null; then
+    echo "Error: rapidfuzz not installed."
+    echo "Run: pip install -r $repo_root/requirements-transcribe.txt"
+    exit 1
+  fi
+  if ! "$PYTHON" -c "import faster_whisper" 2>/dev/null; then
+    echo "Error: faster-whisper not installed."
+    echo "Run: pip install -r $repo_root/requirements-transcribe.txt"
+    exit 1
+  fi
+fi
+
+exec "$PYTHON" "$python_script" "$@"

--- a/src/scripts/inject_no_blocking.py
+++ b/src/scripts/inject_no_blocking.py
@@ -17,11 +17,21 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import json
 import re
 import subprocess
 import sys
 from pathlib import Path
+
+from overhead_inject_common import (
+    build_ffmpeg_command,
+    load_report,
+    load_transcript,
+    max_volume_db,
+    probe_audio,
+    run_verification,
+    seconds_to_hms,
+    write_injections_sidecar,
+)
 
 DEFAULT_CLIP = Path(
     "/Users/jessicasartin/Downloads/15 min round - foam NS 8.5 (no time limit on NB).band"
@@ -43,51 +53,6 @@ COUNTDOWN_TEXT_RE = re.compile(
     r"seven,\s*six,\s*five",
     re.I,
 )
-
-
-def seconds_to_hms(total_seconds: float) -> str:
-    total = max(0, int(round(total_seconds)))
-    h = total // 3600
-    m = (total % 3600) // 60
-    s = total % 60
-    return f"{h:02d}:{m:02d}:{s:02d}"
-
-
-def probe_audio(path: Path) -> dict:
-    cmd = [
-        "ffprobe",
-        "-v",
-        "error",
-        "-select_streams",
-        "a:0",
-        "-show_entries",
-        "stream=sample_rate,channels,codec_name",
-        "-show_entries",
-        "format=duration",
-        "-of",
-        "json",
-        str(path),
-    ]
-    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-    data = json.loads(result.stdout)
-    stream = data["streams"][0]
-    return {
-        "sample_rate": int(stream["sample_rate"]),
-        "channels": int(stream["channels"]),
-        "codec": stream["codec_name"],
-        "duration": float(data["format"]["duration"]),
-    }
-
-
-def load_report(path: Path) -> dict:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def load_transcript(wav_path: Path, transcript_path: Path | None) -> dict | None:
-    path = transcript_path or wav_path.with_suffix(wav_path.suffix + ".transcript.json")
-    if not path.exists():
-        return None
-    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def find_play_end_countdown(round_data: dict) -> dict | None:
@@ -206,33 +171,111 @@ def is_silent_at(
     return False, None
 
 
-def choose_no_blocking_silence(
+def silence_duration(silence: dict) -> float:
+    return float(silence.get("duration") or 0.0)
+
+
+def in_silence_search_window(
+    silence: dict,
+    countdown_start: float,
+    min_after_countdown: float,
+    max_offset: float,
+    min_no_blocking_silence: float,
+) -> bool:
+    """True when silence plausibly begins after the play-end countdown/buzzer."""
+    rel = silence["start"] - countdown_start
+    if rel < 0 or rel > max_offset:
+        return False
+    if silence_duration(silence) >= min_no_blocking_silence:
+        return True
+    return rel >= min_after_countdown
+
+
+def list_no_blocking_silence_candidates(
     silences: list[dict],
     countdown_start: float,
     min_after_countdown: float,
     min_no_blocking_silence: float,
     early_window: float = 45.0,
     late_window: float = 120.0,
-) -> dict | None:
-    def in_early(silence: dict) -> bool:
-        return countdown_start + min_after_countdown <= silence["start"] <= countdown_start + early_window
+) -> list[dict]:
+    """Return silence windows earliest-first (first post-buzzer gap, not longest)."""
+    seen: set[tuple[float, float | None]] = set()
+    ordered: list[dict] = []
 
-    def in_late(silence: dict) -> bool:
-        return countdown_start + min_after_countdown <= silence["start"] <= countdown_start + late_window
-
-    def duration(silence: dict) -> float:
-        return float(silence.get("duration") or 0.0)
-
-    for predicate, min_duration in (
-        (in_early, min_no_blocking_silence),
-        (in_early, 2.0),
-        (in_late, min_no_blocking_silence),
-        (in_late, 2.0),
+    for max_offset, min_duration in (
+        (early_window, min_no_blocking_silence),
+        (early_window, 2.0),
+        (late_window, min_no_blocking_silence),
+        (late_window, 2.0),
     ):
-        candidates = [silence for silence in silences if predicate(silence) and duration(silence) >= min_duration]
-        if candidates:
-            return max(candidates, key=duration)
+        for silence in silences:
+            if silence_duration(silence) < min_duration:
+                continue
+            if not in_silence_search_window(
+                silence,
+                countdown_start,
+                min_after_countdown,
+                max_offset,
+                min_no_blocking_silence,
+            ):
+                continue
+            key = (silence["start"], silence.get("duration"))
+            if key in seen:
+                continue
+            seen.add(key)
+            ordered.append(silence)
+
+    ordered.sort(key=lambda silence: silence["start"])
+    return ordered
+
+
+def speech_before_insert(
+    round_data: dict,
+    countdown_start: float,
+    insert_at: float,
+) -> dict | None:
+    """Return report speech between countdown and insert (excluding the countdown cue itself)."""
+    for item in round_data["speech"]:
+        speech_at = float(item["wav_seconds"])
+        if speech_at <= countdown_start + 0.5 or speech_at >= insert_at:
+            continue
+        if item["role"] == "countdown_play_end":
+            continue
+        return item
     return None
+
+
+def validate_insert_point(
+    wav_path: Path,
+    round_data: dict,
+    countdown_start: float,
+    insert_at: float,
+    noise_db: float,
+    min_silence_detect: float,
+    max_insert_volume_db: float = -45.0,
+) -> dict:
+    verified, verify_silence = is_silent_at(
+        wav_path,
+        insert_at,
+        window_seconds=6.0,
+        noise_db=noise_db,
+        min_silence=min_silence_detect,
+    )
+    max_volume = max_volume_db(wav_path, insert_at)
+    blocking_speech = speech_before_insert(round_data, countdown_start, insert_at)
+    volume_ok = max_volume is not None and max_volume <= max_insert_volume_db
+    speech_ok = blocking_speech is None
+    confidence = "high" if verified and volume_ok and speech_ok else "low"
+
+    return {
+        "insert_verified_silent": verified,
+        "verify_silence_window": verify_silence,
+        "insert_max_volume_db": max_volume,
+        "insert_volume_ok": volume_ok,
+        "insert_speech_overlap": blocking_speech,
+        "insert_confidence": confidence,
+    }
 
 
 def compute_insertions(
@@ -270,36 +313,77 @@ def compute_insertions(
             noise_db,
             min_silence_detect,
         )
-        chosen_silence = choose_no_blocking_silence(
+        candidates = list_no_blocking_silence_candidates(
             silences,
             countdown_start,
             min_after_countdown,
             min_no_blocking_silence,
         )
 
+        chosen_silence: dict | None = None
+        insert_at: float
         method = "silencedetect"
-        if chosen_silence is not None:
+        validation: dict = {}
+
+        for candidate in candidates:
+            candidate_insert = candidate["start"] + offset_after_silence
+            validation = validate_insert_point(
+                wav_path,
+                round_data,
+                countdown_start,
+                candidate_insert,
+                noise_db,
+                min_silence_detect,
+            )
+            if validation["insert_confidence"] == "high":
+                chosen_silence = candidate
+                insert_at = candidate_insert
+                break
+
+        if chosen_silence is None and candidates:
+            chosen_silence = candidates[0]
             insert_at = chosen_silence["start"] + offset_after_silence
-            silence_start = chosen_silence["start"]
-            silence_duration = chosen_silence.get("duration")
+            validation = validate_insert_point(
+                wav_path,
+                round_data,
+                countdown_start,
+                insert_at,
+                noise_db,
+                min_silence_detect,
+            )
+        elif chosen_silence is not None:
+            pass
         elif transcript_end is not None:
             method = "transcript_end_fallback"
-            silence_start = None
-            silence_duration = None
+            chosen_silence = None
             insert_at = transcript_end + fallback_after_countdown_end
+            validation = validate_insert_point(
+                wav_path,
+                round_data,
+                countdown_start,
+                insert_at,
+                noise_db,
+                min_silence_detect,
+            )
         else:
             method = "countdown_start_fallback"
-            silence_start = None
-            silence_duration = None
+            chosen_silence = None
             insert_at = countdown_start + min_after_countdown + fallback_after_countdown_end
+            validation = validate_insert_point(
+                wav_path,
+                round_data,
+                countdown_start,
+                insert_at,
+                noise_db,
+                min_silence_detect,
+            )
 
-        verified, verify_silence = is_silent_at(
-            wav_path,
-            insert_at,
-            window_seconds=6.0,
-            noise_db=noise_db,
-            min_silence=min_silence_detect,
-        )
+        if chosen_silence is not None:
+            silence_start = chosen_silence["start"]
+            silence_duration_val = chosen_silence.get("duration")
+        else:
+            silence_start = None
+            silence_duration_val = None
 
         insertions.append(
             {
@@ -315,62 +399,20 @@ def compute_insertions(
                 "silence_start_hms": (
                     seconds_to_hms(silence_start) if silence_start is not None else None
                 ),
-                "silence_duration_seconds": silence_duration,
+                "silence_duration_seconds": silence_duration_val,
                 "insert_seconds": round(insert_at, 3),
                 "insert_wav_timestamp": seconds_to_hms(insert_at),
                 "insert_method": method,
-                "insert_verified_silent": verified,
-                "verify_silence_window": verify_silence,
+                "insert_verified_silent": validation.get("insert_verified_silent", False),
+                "verify_silence_window": validation.get("verify_silence_window"),
+                "insert_max_volume_db": validation.get("insert_max_volume_db"),
+                "insert_volume_ok": validation.get("insert_volume_ok"),
+                "insert_speech_overlap": validation.get("insert_speech_overlap"),
+                "insert_confidence": validation.get("insert_confidence", "low"),
                 "countdown_text": countdown["text"],
             }
         )
     return insertions
-
-
-def build_ffmpeg_command(
-    wav_path: Path,
-    clip_path: Path,
-    output_path: Path,
-    insert_seconds: list[float],
-    sample_rate: int,
-    channels: int,
-) -> list[str]:
-    if not insert_seconds:
-        raise ValueError("No insertion timestamps provided")
-
-    n = len(insert_seconds)
-    filter_parts: list[str] = []
-    filter_parts.append(f"[1:a]asplit={n}" + "".join(f"[c{i}]" for i in range(n)))
-
-    layout = "stereo" if channels == 2 else "mono"
-    for i, start in enumerate(insert_seconds):
-        delay_ms = int(round(start * 1000))
-        filter_parts.append(
-            f"[c{i}]aresample={sample_rate},aformat=sample_rates={sample_rate}:"
-            f"channel_layouts={layout},adelay={delay_ms}|{delay_ms}[ins{i}]"
-        )
-
-    mix_inputs = "[0:a]" + "".join(f"[ins{i}]" for i in range(n))
-    filter_parts.append(
-        f"{mix_inputs}amix=inputs={n + 1}:duration=first:dropout_transition=0[out]"
-    )
-    filter_complex = ";".join(filter_parts)
-
-    return [
-        "ffmpeg",
-        "-y",
-        "-i",
-        str(wav_path),
-        "-i",
-        str(clip_path),
-        "-filter_complex",
-        filter_complex,
-        "-map",
-        "[out]",
-        "-c:a",
-        "pcm_s16le",
-        str(output_path),
-    ]
 
 
 def resolve_clip_path(args: argparse.Namespace) -> Path:
@@ -389,70 +431,39 @@ def print_insertion_plan(insertions: list[dict], clip_path: Path) -> None:
     print(f"  duration={clip_info['duration']:.1f}s")
     print()
     print(
-        f"{'RND':<4} {'CD START':<10} {'CD END':<10} {'SILENCE':<10} "
-        f"{'INSERT':<10} {'SILENT?':<7} {'METHOD'}"
+        f"{'RND':<4} {'CD START':<10} {'SILENCE':<10} {'INSERT':<10} "
+        f"{'CONF':<5} {'MAX dB':<8} {'METHOD'}"
     )
-    print("-" * 95)
+    print("-" * 85)
     for item in insertions:
         if item["insert_seconds"] is None:
             print(f"{item['round']:<4}  SKIP — {item['reason']}")
             continue
-        cd_end = item.get("countdown_end_transcript_hms") or "—"
         silence = item.get("silence_start_hms") or "—"
-        silent = "yes" if item.get("insert_verified_silent") else "NO"
+        conf = item.get("insert_confidence", "?")
+        max_db = item.get("insert_max_volume_db")
+        max_db_str = f"{max_db:.1f}" if max_db is not None else "—"
         print(
             f"{item['round']:<4} "
             f"{item['play_end_countdown_wav']:<10} "
-            f"{cd_end:<10} "
             f"{silence:<10} "
             f"{item['insert_wav_timestamp']:<10} "
-            f"{silent:<7} "
+            f"{conf:<5} "
+            f"{max_db_str:<8} "
             f"{item['insert_method']}"
         )
-        if item.get("silence_duration_seconds") is not None:
+        overlap = item.get("insert_speech_overlap")
+        if overlap:
             print(
-                f"     silence_duration={item['silence_duration_seconds']:.1f}s  "
-                f"countdown={item['countdown_text'][:55]}"
+                f"     speech before insert: {overlap['wav_timestamp']} "
+                f"[{overlap['role']}] {overlap['text'][:45]}"
             )
-
-
-def run_verification(wav_path: Path, report: dict, repo_root: Path) -> int:
-    verify_script = repo_root / "src/scripts/verify_overhead_schedule.py"
-    if not verify_script.exists():
-        print(f"Warning: verification script not found: {verify_script}", file=sys.stderr)
-        return 0
-
-    schedule_dir = repo_root / "src/output/June2026Tournament/schedule/generated"
-    if not schedule_dir.exists():
-        print(
-            "Warning: default schedule dir not found; skipping verification",
-            file=sys.stderr,
-        )
-        return 0
-
-    wav_start = report.get("wav_start_time", "09:00")
-    python = repo_root / ".venv/bin/python"
-    if not python.exists():
-        python = Path(sys.executable)
-
-    cmd = [
-        str(python),
-        str(verify_script),
-        "--wav",
-        str(wav_path),
-        "--schedule-dir",
-        str(schedule_dir),
-        "--date",
-        "2026-06-20",
-        "--courts",
-        "2,3,4",
-        "--wav-start-time",
-        wav_start,
-        "--by-round",
-    ]
-    print("\nRe-running overhead verification on output wav ...", file=sys.stderr)
-    result = subprocess.run(cmd)
-    return result.returncode
+        elif item.get("silence_duration_seconds") is not None:
+            cd_rel = item["silence_start_seconds"] - item["play_end_countdown_seconds"]
+            print(
+                f"     silence +{cd_rel:.1f}s after countdown, "
+                f"duration={item['silence_duration_seconds']:.1f}s"
+            )
 
 
 def parse_args() -> argparse.Namespace:
@@ -622,18 +633,15 @@ def main() -> int:
     subprocess.run(cmd, check=True)
 
     sidecar = output_path.with_suffix(output_path.suffix + ".injections.json")
-    sidecar.write_text(
-        json.dumps(
-            {
-                "source_wav": str(args.wav),
-                "clip": str(clip_path),
-                "offset_after_silence": args.offset_after_silence,
-                "silence_noise_db": args.silence_noise_db,
-                "insertions": insertions,
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
+    write_injections_sidecar(
+        sidecar,
+        {
+            "source_wav": str(args.wav),
+            "clip": str(clip_path),
+            "offset_after_silence": args.offset_after_silence,
+            "silence_noise_db": args.silence_noise_db,
+            "insertions": insertions,
+        },
     )
     print(f"Insertion log: {sidecar}", file=sys.stderr)
     print(f"Done: {output_path}", file=sys.stderr)

--- a/src/scripts/inject_no_blocking.py
+++ b/src/scripts/inject_no_blocking.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
-Insert no-blocking PA clips into a venue-wide overhead .wav after each play-end countdown.
+Insert no-blocking PA clips into a venue-wide overhead .wav after each play-end buzzer.
 
-Uses play-end countdown timestamps from a by-round overhead verification report and
-overlays a short clip (default: Dance Vocal#31 "three minutes no blocking") at the
-start of each round's silent no-blocking window.
+Uses play-end countdown times from a by-round overhead verification report, then
+ffmpeg silencedetect to find the start of the post-buzzer silent window. Overlays
+the clip a few seconds into that silence (same duration as the source wav).
 
 Usage:
   python inject_no_blocking.py \\
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -32,6 +33,16 @@ CLIP_PRESETS: dict[str, str] = {
     "no_blocking": "Dance Vocal#28.wav",
     "three_minutes_remaining": "Dance Vocal#29.wav",
 }
+
+COUNTDOWN_TEXT_RE = re.compile(
+    r"\b(10|ten)\b.*\b(9|nine)\b|"
+    r"\b7,\s*6,\s*5|"
+    r"\bfive,\s*four|"
+    r"three,\s*two,\s*one|"
+    r"\b2,\s*1\b|"
+    r"seven,\s*six,\s*five",
+    re.I,
+)
 
 
 def seconds_to_hms(total_seconds: float) -> str:
@@ -72,6 +83,13 @@ def load_report(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def load_transcript(wav_path: Path, transcript_path: Path | None) -> dict | None:
+    path = transcript_path or wav_path.with_suffix(wav_path.suffix + ".transcript.json")
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 def find_play_end_countdown(round_data: dict) -> dict | None:
     candidates = [item for item in round_data["speech"] if item["role"] == "countdown_play_end"]
     if not candidates:
@@ -87,11 +105,150 @@ def find_play_end_countdown(round_data: dict) -> dict | None:
     return max(pool, key=lambda item: item["wav_seconds"])
 
 
+def looks_like_countdown(text: str) -> bool:
+    return bool(COUNTDOWN_TEXT_RE.search(text.lower()))
+
+
+def countdown_end_from_transcript(
+    transcript: dict | None,
+    countdown_start: float,
+    search_seconds: float = 35.0,
+) -> float | None:
+    if not transcript:
+        return None
+
+    end: float | None = None
+    window_end = countdown_start + search_seconds
+    for segment in transcript.get("segments", []):
+        start = float(segment["start"])
+        if start < countdown_start - 1.0 or start > window_end:
+            continue
+        if not looks_like_countdown(segment.get("text", "")):
+            continue
+        segment_end = float(segment.get("end", start))
+        segment_duration = segment_end - start
+        if segment_duration > 30.0:
+            segment_end = start + 20.0
+        end = segment_end if end is None else max(end, segment_end)
+    return end
+
+
+def detect_silences(
+    wav_path: Path,
+    start: float,
+    duration: float,
+    noise_db: float,
+    min_silence: float,
+) -> list[dict]:
+    cmd = [
+        "ffmpeg",
+        "-hide_banner",
+        "-ss",
+        str(max(0.0, start)),
+        "-t",
+        str(max(0.1, duration)),
+        "-i",
+        str(wav_path),
+        "-af",
+        f"silencedetect=noise={noise_db}dB:d={min_silence}",
+        "-f",
+        "null",
+        "-",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    stderr = result.stderr
+
+    silences: list[dict] = []
+    current_start: float | None = None
+    for line in stderr.splitlines():
+        if "silence_start:" in line:
+            value = line.split("silence_start:")[-1].strip()
+            current_start = start + float(value)
+        elif "silence_end:" in line and current_start is not None:
+            tail = line.split("silence_end:")[-1].strip()
+            relative_end = float(tail.split("|")[0].strip())
+            duration_match = re.search(r"silence_duration:\s*([0-9.]+)", line)
+            silence_duration = float(duration_match.group(1)) if duration_match else None
+            silences.append(
+                {
+                    "start": current_start,
+                    "end": start + relative_end,
+                    "duration": silence_duration,
+                }
+            )
+            current_start = None
+
+    if current_start is not None:
+        silences.append(
+            {
+                "start": current_start,
+                "end": start + duration,
+                "duration": (start + duration) - current_start,
+            }
+        )
+    return silences
+
+
+def is_silent_at(
+    wav_path: Path,
+    timestamp: float,
+    window_seconds: float,
+    noise_db: float,
+    min_silence: float,
+) -> tuple[bool, dict | None]:
+    """Return True if timestamp falls inside a detected silence window."""
+    search_start = max(0.0, timestamp - window_seconds)
+    search_duration = window_seconds * 2
+    silences = detect_silences(wav_path, search_start, search_duration, noise_db, min_silence)
+    for silence in silences:
+        if silence["start"] <= timestamp <= silence["end"]:
+            return True, silence
+    return False, None
+
+
+def choose_no_blocking_silence(
+    silences: list[dict],
+    countdown_start: float,
+    min_after_countdown: float,
+    min_no_blocking_silence: float,
+    early_window: float = 45.0,
+    late_window: float = 120.0,
+) -> dict | None:
+    def in_early(silence: dict) -> bool:
+        return countdown_start + min_after_countdown <= silence["start"] <= countdown_start + early_window
+
+    def in_late(silence: dict) -> bool:
+        return countdown_start + min_after_countdown <= silence["start"] <= countdown_start + late_window
+
+    def duration(silence: dict) -> float:
+        return float(silence.get("duration") or 0.0)
+
+    for predicate, min_duration in (
+        (in_early, min_no_blocking_silence),
+        (in_early, 2.0),
+        (in_late, min_no_blocking_silence),
+        (in_late, 2.0),
+    ):
+        candidates = [silence for silence in silences if predicate(silence) and duration(silence) >= min_duration]
+        if candidates:
+            return max(candidates, key=duration)
+    return None
+
+
 def compute_insertions(
+    wav_path: Path,
     report: dict,
-    offset_after_play_end: float,
+    transcript: dict | None,
+    offset_after_silence: float,
+    search_window: float,
+    noise_db: float,
+    min_silence_detect: float,
+    min_after_countdown: float,
+    min_no_blocking_silence: float,
+    fallback_after_countdown_end: float,
 ) -> list[dict]:
     insertions: list[dict] = []
+
     for round_data in report["rounds"]:
         countdown = find_play_end_countdown(round_data)
         if countdown is None:
@@ -104,15 +261,66 @@ def compute_insertions(
             )
             continue
 
-        insert_at = countdown["wav_seconds"] + offset_after_play_end
+        countdown_start = float(countdown["wav_seconds"])
+        transcript_end = countdown_end_from_transcript(transcript, countdown_start)
+        silences = detect_silences(
+            wav_path,
+            countdown_start,
+            search_window,
+            noise_db,
+            min_silence_detect,
+        )
+        chosen_silence = choose_no_blocking_silence(
+            silences,
+            countdown_start,
+            min_after_countdown,
+            min_no_blocking_silence,
+        )
+
+        method = "silencedetect"
+        if chosen_silence is not None:
+            insert_at = chosen_silence["start"] + offset_after_silence
+            silence_start = chosen_silence["start"]
+            silence_duration = chosen_silence.get("duration")
+        elif transcript_end is not None:
+            method = "transcript_end_fallback"
+            silence_start = None
+            silence_duration = None
+            insert_at = transcript_end + fallback_after_countdown_end
+        else:
+            method = "countdown_start_fallback"
+            silence_start = None
+            silence_duration = None
+            insert_at = countdown_start + min_after_countdown + fallback_after_countdown_end
+
+        verified, verify_silence = is_silent_at(
+            wav_path,
+            insert_at,
+            window_seconds=6.0,
+            noise_db=noise_db,
+            min_silence=min_silence_detect,
+        )
+
         insertions.append(
             {
                 "round": round_data["round"],
                 "schedule_label": round_data["schedule_label"],
                 "play_end_countdown_wav": countdown["wav_timestamp"],
-                "play_end_countdown_seconds": countdown["wav_seconds"],
+                "play_end_countdown_seconds": countdown_start,
+                "countdown_end_transcript": transcript_end,
+                "countdown_end_transcript_hms": (
+                    seconds_to_hms(transcript_end) if transcript_end is not None else None
+                ),
+                "silence_start_seconds": silence_start,
+                "silence_start_hms": (
+                    seconds_to_hms(silence_start) if silence_start is not None else None
+                ),
+                "silence_duration_seconds": silence_duration,
                 "insert_seconds": round(insert_at, 3),
                 "insert_wav_timestamp": seconds_to_hms(insert_at),
+                "insert_method": method,
+                "insert_verified_silent": verified,
+                "verify_silence_window": verify_silence,
                 "countdown_text": countdown["text"],
             }
         )
@@ -180,21 +388,32 @@ def print_insertion_plan(insertions: list[dict], clip_path: Path) -> None:
     print(f"Clip: {clip_path}")
     print(f"  duration={clip_info['duration']:.1f}s")
     print()
-    print(f"{'RND':<4} {'PLAY-END CD':<12} {'INSERT AT':<12} {'COUNTDOWN TEXT'}")
-    print("-" * 90)
+    print(
+        f"{'RND':<4} {'CD START':<10} {'CD END':<10} {'SILENCE':<10} "
+        f"{'INSERT':<10} {'SILENT?':<7} {'METHOD'}"
+    )
+    print("-" * 95)
     for item in insertions:
         if item["insert_seconds"] is None:
             print(f"{item['round']:<4}  SKIP — {item['reason']}")
             continue
-        text = item["countdown_text"][:50]
-        if len(item["countdown_text"]) > 50:
-            text += "…"
+        cd_end = item.get("countdown_end_transcript_hms") or "—"
+        silence = item.get("silence_start_hms") or "—"
+        silent = "yes" if item.get("insert_verified_silent") else "NO"
         print(
             f"{item['round']:<4} "
-            f"{item['play_end_countdown_wav']:<12} "
-            f"{item['insert_wav_timestamp']:<12} "
-            f"{text}"
+            f"{item['play_end_countdown_wav']:<10} "
+            f"{cd_end:<10} "
+            f"{silence:<10} "
+            f"{item['insert_wav_timestamp']:<10} "
+            f"{silent:<7} "
+            f"{item['insert_method']}"
         )
+        if item.get("silence_duration_seconds") is not None:
+            print(
+                f"     silence_duration={item['silence_duration_seconds']:.1f}s  "
+                f"countdown={item['countdown_text'][:55]}"
+            )
 
 
 def run_verification(wav_path: Path, report: dict, repo_root: Path) -> int:
@@ -238,7 +457,10 @@ def run_verification(wav_path: Path, report: dict, repo_root: Path) -> int:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Insert no-blocking PA clips after each play-end countdown in an overhead .wav."
+        description=(
+            "Overlay no-blocking PA clips after each play-end buzzer using silencedetect "
+            "to locate the post-countdown silent window."
+        )
     )
     parser.add_argument("--wav", type=Path, required=True, help="Source overhead .wav")
     parser.add_argument(
@@ -247,10 +469,11 @@ def parse_args() -> argparse.Namespace:
         help="By-round report JSON (default: {wav_stem}_overhead_by_round_report.json beside wav)",
     )
     parser.add_argument(
-        "--clip",
+        "--transcript",
         type=Path,
-        help="No-blocking clip .wav to insert",
+        help="Transcript JSON for countdown end times (default: {wav}.transcript.json)",
     )
+    parser.add_argument("--clip", type=Path, help="No-blocking clip .wav to insert")
     parser.add_argument(
         "--clip-preset",
         choices=sorted(CLIP_PRESETS),
@@ -264,10 +487,46 @@ def parse_args() -> argparse.Namespace:
         help="GarageBand .band directory containing Media/Audio Files",
     )
     parser.add_argument(
-        "--offset-after-play-end",
+        "--offset-after-silence",
         type=float,
-        default=20.0,
-        help="Seconds after play-end countdown start to place clip (default: 20)",
+        default=3.0,
+        help="Seconds after detected silence start to place clip (default: 3)",
+    )
+    parser.add_argument(
+        "--search-window",
+        type=float,
+        default=180.0,
+        help="Seconds after play-end countdown to search for silence (default: 180)",
+    )
+    parser.add_argument(
+        "--silence-noise-db",
+        type=float,
+        default=-35.0,
+        help="silencedetect noise threshold in dB (default: -35)",
+    )
+    parser.add_argument(
+        "--min-silence-detect",
+        type=float,
+        default=0.3,
+        help="Minimum silence duration for silencedetect in seconds (default: 0.3)",
+    )
+    parser.add_argument(
+        "--min-after-countdown",
+        type=float,
+        default=3.0,
+        help="Ignore silence earlier than this many seconds after countdown start (default: 3)",
+    )
+    parser.add_argument(
+        "--min-no-blocking-silence",
+        type=float,
+        default=15.0,
+        help="Prefer silence at least this long for the no-blocking window (default: 15)",
+    )
+    parser.add_argument(
+        "--fallback-after-countdown-end",
+        type=float,
+        default=3.0,
+        help="If silencedetect fails, seconds after transcript countdown end (default: 3)",
     )
     parser.add_argument(
         "--output",
@@ -283,6 +542,11 @@ def parse_args() -> argparse.Namespace:
         "--verify",
         action="store_true",
         help="Run verify_overhead_schedule.py --by-round on the output wav",
+    )
+    parser.add_argument(
+        "--require-silence-verify",
+        action="store_true",
+        help="Fail if any insertion point is not verified silent",
     )
     return parser.parse_args()
 
@@ -311,13 +575,31 @@ def main() -> int:
         return 1
 
     report = load_report(report_path)
-    insertions = compute_insertions(report, args.offset_after_play_end)
+    transcript = load_transcript(args.wav, args.transcript)
+    insertions = compute_insertions(
+        args.wav,
+        report,
+        transcript,
+        args.offset_after_silence,
+        args.search_window,
+        args.silence_noise_db,
+        args.min_silence_detect,
+        args.min_after_countdown,
+        args.min_no_blocking_silence,
+        args.fallback_after_countdown_end,
+    )
     valid = [item for item in insertions if item["insert_seconds"] is not None]
     if not valid:
         print("Error: no insertion points found in report.", file=sys.stderr)
         return 1
 
     print_insertion_plan(insertions, clip_path)
+
+    unverified = [item for item in valid if not item.get("insert_verified_silent")]
+    if unverified:
+        print(f"\nWarning: {len(unverified)} insertion point(s) not verified silent.", file=sys.stderr)
+        if args.require_silence_verify:
+            return 1
 
     if args.dry_run:
         print(f"\nDry run: would insert {len(valid)} clip(s).")
@@ -345,7 +627,8 @@ def main() -> int:
             {
                 "source_wav": str(args.wav),
                 "clip": str(clip_path),
-                "offset_after_play_end": args.offset_after_play_end,
+                "offset_after_silence": args.offset_after_silence,
+                "silence_noise_db": args.silence_noise_db,
                 "insertions": insertions,
             },
             indent=2,

--- a/src/scripts/inject_no_blocking.py
+++ b/src/scripts/inject_no_blocking.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""
+Insert no-blocking PA clips into a venue-wide overhead .wav after each play-end countdown.
+
+Uses play-end countdown timestamps from a by-round overhead verification report and
+overlays a short clip (default: Dance Vocal#31 "three minutes no blocking") at the
+start of each round's silent no-blocking window.
+
+Usage:
+  python inject_no_blocking.py \\
+    --wav "/path/to/BDL Throwdown 5 Full Timeline.wav" \\
+    --report "/path/to/BDL Throwdown 5 Full Timeline_overhead_by_round_report.json"
+
+  python inject_no_blocking.py --wav ... --report ... --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_CLIP = Path(
+    "/Users/jessicasartin/Downloads/15 min round - foam NS 8.5 (no time limit on NB).band"
+    "/Media/Audio Files/Dance Vocal#31.wav"
+)
+
+CLIP_PRESETS: dict[str, str] = {
+    "three_minutes_no_blocking": "Dance Vocal#31.wav",
+    "no_blocking": "Dance Vocal#28.wav",
+    "three_minutes_remaining": "Dance Vocal#29.wav",
+}
+
+
+def seconds_to_hms(total_seconds: float) -> str:
+    total = max(0, int(round(total_seconds)))
+    h = total // 3600
+    m = (total % 3600) // 60
+    s = total % 60
+    return f"{h:02d}:{m:02d}:{s:02d}"
+
+
+def probe_audio(path: Path) -> dict:
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-select_streams",
+        "a:0",
+        "-show_entries",
+        "stream=sample_rate,channels,codec_name",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "json",
+        str(path),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout)
+    stream = data["streams"][0]
+    return {
+        "sample_rate": int(stream["sample_rate"]),
+        "channels": int(stream["channels"]),
+        "codec": stream["codec_name"],
+        "duration": float(data["format"]["duration"]),
+    }
+
+
+def load_report(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def find_play_end_countdown(round_data: dict) -> dict | None:
+    candidates = [item for item in round_data["speech"] if item["role"] == "countdown_play_end"]
+    if not candidates:
+        return None
+
+    boundary = next(
+        (item for item in round_data["speech"] if item["role"] == "countdown_round_boundary"),
+        None,
+    )
+    boundary_wav = boundary["wav_seconds"] if boundary else float("inf")
+    in_window = [item for item in candidates if item["wav_seconds"] < boundary_wav]
+    pool = in_window or candidates
+    return max(pool, key=lambda item: item["wav_seconds"])
+
+
+def compute_insertions(
+    report: dict,
+    offset_after_play_end: float,
+) -> list[dict]:
+    insertions: list[dict] = []
+    for round_data in report["rounds"]:
+        countdown = find_play_end_countdown(round_data)
+        if countdown is None:
+            insertions.append(
+                {
+                    "round": round_data["round"],
+                    "insert_seconds": None,
+                    "reason": "no play-end countdown found in report speech",
+                }
+            )
+            continue
+
+        insert_at = countdown["wav_seconds"] + offset_after_play_end
+        insertions.append(
+            {
+                "round": round_data["round"],
+                "schedule_label": round_data["schedule_label"],
+                "play_end_countdown_wav": countdown["wav_timestamp"],
+                "play_end_countdown_seconds": countdown["wav_seconds"],
+                "insert_seconds": round(insert_at, 3),
+                "insert_wav_timestamp": seconds_to_hms(insert_at),
+                "countdown_text": countdown["text"],
+            }
+        )
+    return insertions
+
+
+def build_ffmpeg_command(
+    wav_path: Path,
+    clip_path: Path,
+    output_path: Path,
+    insert_seconds: list[float],
+    sample_rate: int,
+    channels: int,
+) -> list[str]:
+    if not insert_seconds:
+        raise ValueError("No insertion timestamps provided")
+
+    n = len(insert_seconds)
+    filter_parts: list[str] = []
+    filter_parts.append(f"[1:a]asplit={n}" + "".join(f"[c{i}]" for i in range(n)))
+
+    layout = "stereo" if channels == 2 else "mono"
+    for i, start in enumerate(insert_seconds):
+        delay_ms = int(round(start * 1000))
+        filter_parts.append(
+            f"[c{i}]aresample={sample_rate},aformat=sample_rates={sample_rate}:"
+            f"channel_layouts={layout},adelay={delay_ms}|{delay_ms}[ins{i}]"
+        )
+
+    mix_inputs = "[0:a]" + "".join(f"[ins{i}]" for i in range(n))
+    filter_parts.append(
+        f"{mix_inputs}amix=inputs={n + 1}:duration=first:dropout_transition=0[out]"
+    )
+    filter_complex = ";".join(filter_parts)
+
+    return [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(wav_path),
+        "-i",
+        str(clip_path),
+        "-filter_complex",
+        filter_complex,
+        "-map",
+        "[out]",
+        "-c:a",
+        "pcm_s16le",
+        str(output_path),
+    ]
+
+
+def resolve_clip_path(args: argparse.Namespace) -> Path:
+    if args.clip:
+        return args.clip.expanduser()
+    if args.clip_preset:
+        band_dir = args.band_dir.expanduser()
+        filename = CLIP_PRESETS[args.clip_preset]
+        return band_dir / "Media/Audio Files" / filename
+    return DEFAULT_CLIP
+
+
+def print_insertion_plan(insertions: list[dict], clip_path: Path) -> None:
+    clip_info = probe_audio(clip_path)
+    print(f"Clip: {clip_path}")
+    print(f"  duration={clip_info['duration']:.1f}s")
+    print()
+    print(f"{'RND':<4} {'PLAY-END CD':<12} {'INSERT AT':<12} {'COUNTDOWN TEXT'}")
+    print("-" * 90)
+    for item in insertions:
+        if item["insert_seconds"] is None:
+            print(f"{item['round']:<4}  SKIP — {item['reason']}")
+            continue
+        text = item["countdown_text"][:50]
+        if len(item["countdown_text"]) > 50:
+            text += "…"
+        print(
+            f"{item['round']:<4} "
+            f"{item['play_end_countdown_wav']:<12} "
+            f"{item['insert_wav_timestamp']:<12} "
+            f"{text}"
+        )
+
+
+def run_verification(wav_path: Path, report: dict, repo_root: Path) -> int:
+    verify_script = repo_root / "src/scripts/verify_overhead_schedule.py"
+    if not verify_script.exists():
+        print(f"Warning: verification script not found: {verify_script}", file=sys.stderr)
+        return 0
+
+    schedule_dir = repo_root / "src/output/June2026Tournament/schedule/generated"
+    if not schedule_dir.exists():
+        print(
+            "Warning: default schedule dir not found; skipping verification",
+            file=sys.stderr,
+        )
+        return 0
+
+    wav_start = report.get("wav_start_time", "09:00")
+    python = repo_root / ".venv/bin/python"
+    if not python.exists():
+        python = Path(sys.executable)
+
+    cmd = [
+        str(python),
+        str(verify_script),
+        "--wav",
+        str(wav_path),
+        "--schedule-dir",
+        str(schedule_dir),
+        "--date",
+        "2026-06-20",
+        "--courts",
+        "2,3,4",
+        "--wav-start-time",
+        wav_start,
+        "--by-round",
+    ]
+    print("\nRe-running overhead verification on output wav ...", file=sys.stderr)
+    result = subprocess.run(cmd)
+    return result.returncode
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Insert no-blocking PA clips after each play-end countdown in an overhead .wav."
+    )
+    parser.add_argument("--wav", type=Path, required=True, help="Source overhead .wav")
+    parser.add_argument(
+        "--report",
+        type=Path,
+        help="By-round report JSON (default: {wav_stem}_overhead_by_round_report.json beside wav)",
+    )
+    parser.add_argument(
+        "--clip",
+        type=Path,
+        help="No-blocking clip .wav to insert",
+    )
+    parser.add_argument(
+        "--clip-preset",
+        choices=sorted(CLIP_PRESETS),
+        default="three_minutes_no_blocking",
+        help="Clip from --band-dir (default: three_minutes_no_blocking / Dance Vocal#31)",
+    )
+    parser.add_argument(
+        "--band-dir",
+        type=Path,
+        default=DEFAULT_CLIP.parent.parent.parent,
+        help="GarageBand .band directory containing Media/Audio Files",
+    )
+    parser.add_argument(
+        "--offset-after-play-end",
+        type=float,
+        default=20.0,
+        help="Seconds after play-end countdown start to place clip (default: 20)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Output .wav path (default: {wav_stem}_with_no_blocking.wav)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print insertion plan only; do not write output",
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Run verify_overhead_schedule.py --by-round on the output wav",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    if not args.wav.exists():
+        print(f"Error: WAV not found: {args.wav}", file=sys.stderr)
+        return 1
+
+    report_path = args.report or args.wav.with_name(
+        f"{args.wav.stem}_overhead_by_round_report.json"
+    )
+    if not report_path.exists():
+        print(
+            f"Error: report not found: {report_path}\n"
+            "Run verify_overhead_schedule.py --by-round first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    clip_path = resolve_clip_path(args)
+    if not clip_path.exists():
+        print(f"Error: clip not found: {clip_path}", file=sys.stderr)
+        return 1
+
+    report = load_report(report_path)
+    insertions = compute_insertions(report, args.offset_after_play_end)
+    valid = [item for item in insertions if item["insert_seconds"] is not None]
+    if not valid:
+        print("Error: no insertion points found in report.", file=sys.stderr)
+        return 1
+
+    print_insertion_plan(insertions, clip_path)
+
+    if args.dry_run:
+        print(f"\nDry run: would insert {len(valid)} clip(s).")
+        return 0
+
+    output_path = args.output or args.wav.with_name(f"{args.wav.stem}_with_no_blocking.wav")
+    wav_info = probe_audio(args.wav)
+    insert_seconds = [item["insert_seconds"] for item in valid]
+
+    cmd = build_ffmpeg_command(
+        args.wav,
+        clip_path,
+        output_path,
+        insert_seconds,
+        wav_info["sample_rate"],
+        wav_info["channels"],
+    )
+    print(f"\nWriting: {output_path}", file=sys.stderr)
+    print(f"Inserting {len(insert_seconds)} clip(s) with ffmpeg ...", file=sys.stderr)
+    subprocess.run(cmd, check=True)
+
+    sidecar = output_path.with_suffix(output_path.suffix + ".injections.json")
+    sidecar.write_text(
+        json.dumps(
+            {
+                "source_wav": str(args.wav),
+                "clip": str(clip_path),
+                "offset_after_play_end": args.offset_after_play_end,
+                "insertions": insertions,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    print(f"Insertion log: {sidecar}", file=sys.stderr)
+    print(f"Done: {output_path}", file=sys.stderr)
+
+    if args.verify:
+        return run_verification(output_path, report, Path(__file__).resolve().parents[2])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scripts/inject_start_buzzer.py
+++ b/src/scripts/inject_start_buzzer.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""
+Insert Start buzzer clips into a venue-wide overhead .wav at each round's play start.
+
+Uses play_start times from a by-round overhead verification report, then transcript
+phrase-end detection to place the buzzer immediately after "Players line up / here we go".
+
+Usage:
+  python inject_start_buzzer.py \\
+    --wav "/path/to/BDL Throwdown 5 Full Timeline_with_no_blocking.wav" \\
+    --report "/path/to/..._overhead_by_round_report.json" \\
+    --transcript "/path/to/BDL Throwdown 5 Full Timeline.wav.transcript.json"
+
+  python inject_start_buzzer.py --wav ... --report ... --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from overhead_inject_common import (
+    build_ffmpeg_command,
+    load_report,
+    load_transcript,
+    max_volume_db,
+    probe_audio,
+    run_verification,
+    seconds_to_hms,
+    write_injections_sidecar,
+)
+
+DEFAULT_BAND_DIR = Path(
+    "/Users/jessicasartin/Downloads/15 min round - foam NS 8.5 (no time limit on NB).band"
+)
+DEFAULT_CLIP = DEFAULT_BAND_DIR / "Media/Audio Files/Start buzzer"
+
+PLAY_START_TEXT_RE = re.compile(r"players line up|here we go", re.I)
+
+MAX_PHRASE_DURATION_FROM_ANCHOR = 7.0
+
+
+def segment_play_start_end(segment: dict) -> float:
+    """Return a plausible end time for a play-start transcript segment."""
+    start = float(segment["start"])
+    end = float(segment.get("end", start))
+    text = segment.get("text", "").lower()
+    has_line_up = "players line up" in text or "line up" in text
+    has_here_we_go = "here we go" in text
+
+    if has_line_up and has_here_we_go:
+        max_duration = 4.5
+    elif has_here_we_go:
+        max_duration = 2.5
+    elif has_line_up:
+        max_duration = 3.0
+    else:
+        max_duration = 4.0
+
+    if end - start > max_duration:
+        end = start + max_duration
+    return end
+
+
+def estimate_phrase_end_from_report(play_start_cues: list[dict]) -> float:
+    first = min(play_start_cues, key=lambda item: item["wav_seconds"])
+    last = max(play_start_cues, key=lambda item: item["wav_seconds"])
+    anchor = float(first["wav_seconds"])
+    if len(play_start_cues) == 1:
+        return anchor + 4.0
+    return float(last["wav_seconds"]) + 2.0
+
+
+def find_play_start_cues(round_data: dict) -> list[dict]:
+    return [item for item in round_data["speech"] if item["role"] == "play_start"]
+
+
+def find_halfway(round_data: dict) -> dict | None:
+    candidates = [item for item in round_data["speech"] if item["role"] == "halfway"]
+    if not candidates:
+        return None
+    return min(candidates, key=lambda item: item["wav_seconds"])
+
+
+def looks_like_play_start(text: str) -> bool:
+    return bool(PLAY_START_TEXT_RE.search(text.lower()))
+
+
+def play_start_phrase_end_from_transcript(
+    transcript: dict | None,
+    first_play_start: float,
+    search_seconds: float = 12.0,
+) -> float | None:
+    if not transcript:
+        return None
+
+    end: float | None = None
+    window_start = first_play_start - 0.5
+    window_end = first_play_start + search_seconds
+    for segment in transcript.get("segments", []):
+        start = float(segment["start"])
+        if start < window_start or start > window_end:
+            continue
+        if not looks_like_play_start(segment.get("text", "")):
+            continue
+        segment_end = segment_play_start_end(segment)
+        end = segment_end if end is None else max(end, segment_end)
+    return end
+
+
+def speech_overlap_before_insert(
+    round_data: dict,
+    first_play_start: float,
+    insert_at: float,
+) -> dict | None:
+    """Return non-play_start speech between play_start anchor and insert."""
+    for item in round_data["speech"]:
+        speech_at = float(item["wav_seconds"])
+        if speech_at <= first_play_start + 0.5 or speech_at >= insert_at:
+            continue
+        if item["role"] == "play_start":
+            continue
+        return item
+    return None
+
+
+def validate_insert_point(
+    wav_path: Path,
+    round_data: dict,
+    first_play_start: float,
+    insert_at: float,
+    phrase_end: float | None,
+    max_loud_volume_db: float = -20.0,
+) -> dict:
+    max_volume = max_volume_db(wav_path, insert_at)
+    blocking_speech = speech_overlap_before_insert(round_data, first_play_start, insert_at)
+    phrase_clear = phrase_end is None or insert_at >= phrase_end - 0.1
+    speech_ok = blocking_speech is None
+    volume_ok = max_volume is None or max_volume <= max_loud_volume_db
+    halfway = find_halfway(round_data)
+    before_halfway = (
+        halfway is None or insert_at < float(halfway["wav_seconds"])
+    )
+    confidence = "high" if phrase_clear and speech_ok and before_halfway else "low"
+
+    return {
+        "insert_max_volume_db": max_volume,
+        "insert_volume_ok": volume_ok,
+        "insert_speech_overlap": blocking_speech,
+        "insert_phrase_clear": phrase_clear,
+        "insert_before_halfway": before_halfway,
+        "insert_confidence": confidence,
+    }
+
+
+def compute_insertions(
+    wav_path: Path,
+    report: dict,
+    transcript: dict | None,
+    offset_after_phrase_end: float,
+    fallback_offset_after_play_start: float,
+    search_seconds: float,
+) -> list[dict]:
+    insertions: list[dict] = []
+
+    for round_data in report["rounds"]:
+        play_start_cues = find_play_start_cues(round_data)
+        if not play_start_cues:
+            insertions.append(
+                {
+                    "round": round_data["round"],
+                    "insert_seconds": None,
+                    "reason": "no play_start found in report speech",
+                }
+            )
+            continue
+
+        first_play_start = min(play_start_cues, key=lambda item: item["wav_seconds"])
+        last_play_start = max(play_start_cues, key=lambda item: item["wav_seconds"])
+        anchor_seconds = float(first_play_start["wav_seconds"])
+        transcript_end = play_start_phrase_end_from_transcript(
+            transcript,
+            anchor_seconds,
+            search_seconds,
+        )
+        report_end = estimate_phrase_end_from_report(play_start_cues)
+
+        if transcript_end is not None and (
+            transcript_end - anchor_seconds <= MAX_PHRASE_DURATION_FROM_ANCHOR
+        ):
+            phrase_end = transcript_end
+            method = "transcript_phrase_end"
+        elif transcript is not None:
+            phrase_end = report_end
+            method = "report_estimate"
+        else:
+            phrase_end = anchor_seconds + fallback_offset_after_play_start
+            method = "play_start_fallback"
+
+        insert_at = phrase_end + offset_after_phrase_end
+
+        validation = validate_insert_point(
+            wav_path,
+            round_data,
+            anchor_seconds,
+            insert_at,
+            phrase_end,
+        )
+
+        insertions.append(
+            {
+                "round": round_data["round"],
+                "schedule_label": round_data["schedule_label"],
+                "play_start_wav": first_play_start["wav_timestamp"],
+                "play_start_seconds": anchor_seconds,
+                "play_start_text": first_play_start["text"],
+                "play_start_segments": len(play_start_cues),
+                "last_play_start_wav": last_play_start["wav_timestamp"],
+                "last_play_start_seconds": float(last_play_start["wav_seconds"]),
+                "last_play_start_text": last_play_start["text"],
+                "phrase_end_transcript": phrase_end,
+                "phrase_end_transcript_hms": (
+                    seconds_to_hms(phrase_end) if phrase_end is not None else None
+                ),
+                "insert_seconds": round(insert_at, 3),
+                "insert_wav_timestamp": seconds_to_hms(insert_at),
+                "insert_method": method,
+                "insert_max_volume_db": validation.get("insert_max_volume_db"),
+                "insert_volume_ok": validation.get("insert_volume_ok"),
+                "insert_speech_overlap": validation.get("insert_speech_overlap"),
+                "insert_phrase_clear": validation.get("insert_phrase_clear"),
+                "insert_before_halfway": validation.get("insert_before_halfway"),
+                "insert_confidence": validation.get("insert_confidence", "low"),
+            }
+        )
+    return insertions
+
+
+def resolve_clip_path(args: argparse.Namespace) -> Path:
+    if args.clip:
+        return args.clip.expanduser()
+    return args.band_dir.expanduser() / "Media/Audio Files/Start buzzer"
+
+
+def resolve_transcript_path(args: argparse.Namespace) -> Path | None:
+    if args.transcript:
+        return args.transcript.expanduser()
+    # Original export transcript (timestamps unchanged after no-blocking overlay).
+    stem = args.wav.stem.replace("_with_no_blocking", "")
+    candidate = args.wav.with_name(f"{stem}.transcript.json")
+    return candidate if candidate.exists() else None
+
+
+def resolve_upstream_injections(args: argparse.Namespace) -> Path | None:
+    if args.upstream_injections:
+        path = args.upstream_injections.expanduser()
+        return path if path.exists() else None
+    candidate = args.wav.with_suffix(args.wav.suffix + ".injections.json")
+    return candidate if candidate.exists() else None
+
+
+def print_insertion_plan(insertions: list[dict], clip_path: Path) -> None:
+    clip_info = probe_audio(clip_path)
+    print(f"Clip: {clip_path}")
+    print(f"  duration={clip_info['duration']:.1f}s")
+    print()
+    print(
+        f"{'RND':<4} {'PLAY START':<10} {'PHRASE END':<10} {'INSERT':<10} "
+        f"{'CONF':<5} {'MAX dB':<8} {'METHOD'}"
+    )
+    print("-" * 85)
+    for item in insertions:
+        if item["insert_seconds"] is None:
+            print(f"{item['round']:<4}  SKIP — {item['reason']}")
+            continue
+        phrase_end = item.get("phrase_end_transcript_hms") or "—"
+        conf = item.get("insert_confidence", "?")
+        max_db = item.get("insert_max_volume_db")
+        max_db_str = f"{max_db:.1f}" if max_db is not None else "—"
+        print(
+            f"{item['round']:<4} "
+            f"{item['play_start_wav']:<10} "
+            f"{phrase_end:<10} "
+            f"{item['insert_wav_timestamp']:<10} "
+            f"{conf:<5} "
+            f"{max_db_str:<8} "
+            f"{item['insert_method']}"
+        )
+        if item.get("play_start_segments", 1) > 1:
+            print(
+                f"     split phrase: {item['play_start_text']!r} → "
+                f"{item['last_play_start_text']!r}"
+            )
+        overlap = item.get("insert_speech_overlap")
+        if overlap:
+            print(
+                f"     speech before insert: {overlap['wav_timestamp']} "
+                f"[{overlap['role']}] {overlap['text'][:45]}"
+            )
+        if not item.get("insert_before_halfway", True):
+            print("     warning: insert at or after halfway cue")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Overlay Start buzzer clips at each round's play start, immediately after "
+            "'Players line up / here we go'."
+        )
+    )
+    parser.add_argument("--wav", type=Path, required=True, help="Source overhead .wav")
+    parser.add_argument(
+        "--report",
+        type=Path,
+        help="By-round report JSON (default: {wav_stem}_overhead_by_round_report.json beside wav)",
+    )
+    parser.add_argument(
+        "--transcript",
+        type=Path,
+        help="Transcript JSON (default: original {stem}.transcript.json beside wav dir)",
+    )
+    parser.add_argument("--clip", type=Path, help="Start buzzer clip to insert")
+    parser.add_argument(
+        "--band-dir",
+        type=Path,
+        default=DEFAULT_BAND_DIR,
+        help="GarageBand .band directory containing Media/Audio Files",
+    )
+    parser.add_argument(
+        "--offset-after-phrase-end",
+        type=float,
+        default=0.0,
+        help="Seconds after detected phrase end to place clip (default: 0)",
+    )
+    parser.add_argument(
+        "--fallback-offset-after-play-start",
+        type=float,
+        default=4.0,
+        help="Seconds after play_start when transcript unavailable (default: 4)",
+    )
+    parser.add_argument(
+        "--search-seconds",
+        type=float,
+        default=12.0,
+        help="Seconds after play_start to search transcript (default: 12)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Output .wav path (default: {wav_stem}_with_no_blocking_and_start_buzzer.wav)",
+    )
+    parser.add_argument(
+        "--upstream-injections",
+        type=Path,
+        help="Prior injections sidecar (default: {wav}.injections.json)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print insertion plan only; do not write output",
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Run verify_overhead_schedule.py --by-round on the output wav",
+    )
+    parser.add_argument(
+        "--require-phrase-clear",
+        action="store_true",
+        help="Fail if any insertion overlaps speech or lands before phrase end",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    if not args.wav.exists():
+        print(f"Error: WAV not found: {args.wav}", file=sys.stderr)
+        return 1
+
+    report_path = args.report or args.wav.with_name(
+        f"{args.wav.stem}_overhead_by_round_report.json"
+    )
+    if not report_path.exists():
+        print(
+            f"Error: report not found: {report_path}\n"
+            "Run verify_overhead_schedule.py --by-round first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    clip_path = resolve_clip_path(args)
+    if not clip_path.exists():
+        print(f"Error: clip not found: {clip_path}", file=sys.stderr)
+        return 1
+
+    report = load_report(report_path)
+    transcript_path = resolve_transcript_path(args)
+    transcript = load_transcript(args.wav, transcript_path) if transcript_path else None
+    if transcript is None and transcript_path is None:
+        print(
+            "Warning: no transcript found; using play_start + fallback offset.",
+            file=sys.stderr,
+        )
+
+    insertions = compute_insertions(
+        args.wav,
+        report,
+        transcript,
+        args.offset_after_phrase_end,
+        args.fallback_offset_after_play_start,
+        args.search_seconds,
+    )
+    valid = [item for item in insertions if item["insert_seconds"] is not None]
+    if not valid:
+        print("Error: no insertion points found in report.", file=sys.stderr)
+        return 1
+
+    print_insertion_plan(insertions, clip_path)
+
+    unclear = [
+        item
+        for item in valid
+        if not item.get("insert_phrase_clear") or item.get("insert_speech_overlap")
+    ]
+    if unclear:
+        print(
+            f"\nWarning: {len(unclear)} insertion point(s) have speech overlap or unclear phrase end.",
+            file=sys.stderr,
+        )
+        if args.require_phrase_clear:
+            return 1
+
+    if args.dry_run:
+        print(f"\nDry run: would insert {len(valid)} clip(s).")
+        return 0
+
+    output_path = args.output
+    if output_path is None:
+        stem = args.wav.stem
+        if stem.endswith("_with_no_blocking"):
+            out_stem = stem + "_and_start_buzzer"
+        else:
+            out_stem = f"{stem}_with_no_blocking_and_start_buzzer"
+        output_path = args.wav.with_name(f"{out_stem}.wav")
+    wav_info = probe_audio(args.wav)
+    insert_seconds = [item["insert_seconds"] for item in valid]
+
+    cmd = build_ffmpeg_command(
+        args.wav,
+        clip_path,
+        output_path,
+        insert_seconds,
+        wav_info["sample_rate"],
+        wav_info["channels"],
+    )
+    print(f"\nWriting: {output_path}", file=sys.stderr)
+    print(f"Inserting {len(insert_seconds)} clip(s) with ffmpeg ...", file=sys.stderr)
+    subprocess.run(cmd, check=True)
+
+    upstream = resolve_upstream_injections(args)
+    sidecar = output_path.with_suffix(output_path.suffix + ".injections.json")
+    payload: dict = {
+        "source_wav": str(args.wav),
+        "clip": str(clip_path),
+        "injection_type": "start_buzzer",
+        "offset_after_phrase_end": args.offset_after_phrase_end,
+        "fallback_offset_after_play_start": args.fallback_offset_after_play_start,
+        "insertions": insertions,
+    }
+    if upstream:
+        payload["upstream_injections"] = str(upstream)
+    write_injections_sidecar(sidecar, payload)
+    print(f"Insertion log: {sidecar}", file=sys.stderr)
+    print(f"Done: {output_path}", file=sys.stderr)
+
+    if args.verify:
+        return run_verification(output_path, report, Path(__file__).resolve().parents[2])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scripts/overhead_inject_common.py
+++ b/src/scripts/overhead_inject_common.py
@@ -1,0 +1,166 @@
+"""Shared utilities for overlaying PA clips into venue-wide overhead .wav files."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def seconds_to_hms(total_seconds: float) -> str:
+    total = max(0, int(round(total_seconds)))
+    h = total // 3600
+    m = (total % 3600) // 60
+    s = total % 60
+    return f"{h:02d}:{m:02d}:{s:02d}"
+
+
+def probe_audio(path: Path) -> dict:
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-select_streams",
+        "a:0",
+        "-show_entries",
+        "stream=sample_rate,channels,codec_name",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "json",
+        str(path),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout)
+    stream = data["streams"][0]
+    return {
+        "sample_rate": int(stream["sample_rate"]),
+        "channels": int(stream["channels"]),
+        "codec": stream["codec_name"],
+        "duration": float(data["format"]["duration"]),
+    }
+
+
+def load_report(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_transcript(wav_path: Path, transcript_path: Path | None) -> dict | None:
+    path = transcript_path or wav_path.with_suffix(wav_path.suffix + ".transcript.json")
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def max_volume_db(wav_path: Path, timestamp: float, window_seconds: float = 0.5) -> float | None:
+    cmd = [
+        "ffmpeg",
+        "-hide_banner",
+        "-ss",
+        str(max(0.0, timestamp)),
+        "-t",
+        str(max(0.05, window_seconds)),
+        "-i",
+        str(wav_path),
+        "-af",
+        "volumedetect",
+        "-f",
+        "null",
+        "-",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    for line in result.stderr.splitlines():
+        if "max_volume:" in line:
+            value = line.split("max_volume:")[-1].strip().split()[0]
+            return float(value.replace("dB", ""))
+    return None
+
+
+def build_ffmpeg_command(
+    wav_path: Path,
+    clip_path: Path,
+    output_path: Path,
+    insert_seconds: list[float],
+    sample_rate: int,
+    channels: int,
+) -> list[str]:
+    if not insert_seconds:
+        raise ValueError("No insertion timestamps provided")
+
+    n = len(insert_seconds)
+    filter_parts: list[str] = []
+    filter_parts.append(f"[1:a]asplit={n}" + "".join(f"[c{i}]" for i in range(n)))
+
+    layout = "stereo" if channels == 2 else "mono"
+    for i, start in enumerate(insert_seconds):
+        delay_ms = int(round(start * 1000))
+        filter_parts.append(
+            f"[c{i}]aresample={sample_rate},aformat=sample_rates={sample_rate}:"
+            f"channel_layouts={layout},adelay={delay_ms}|{delay_ms}[ins{i}]"
+        )
+
+    mix_inputs = "[0:a]" + "".join(f"[ins{i}]" for i in range(n))
+    filter_parts.append(
+        f"{mix_inputs}amix=inputs={n + 1}:duration=first:dropout_transition=0[out]"
+    )
+    filter_complex = ";".join(filter_parts)
+
+    return [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(wav_path),
+        "-i",
+        str(clip_path),
+        "-filter_complex",
+        filter_complex,
+        "-map",
+        "[out]",
+        "-c:a",
+        "pcm_s16le",
+        str(output_path),
+    ]
+
+
+def run_verification(wav_path: Path, report: dict, repo_root: Path) -> int:
+    verify_script = repo_root / "src/scripts/verify_overhead_schedule.py"
+    if not verify_script.exists():
+        print(f"Warning: verification script not found: {verify_script}", file=sys.stderr)
+        return 0
+
+    schedule_dir = repo_root / "src/output/June2026Tournament/schedule/generated"
+    if not schedule_dir.exists():
+        print(
+            "Warning: default schedule dir not found; skipping verification",
+            file=sys.stderr,
+        )
+        return 0
+
+    wav_start = report.get("wav_start_time", "09:00")
+    python = repo_root / ".venv/bin/python"
+    if not python.exists():
+        python = Path(sys.executable)
+
+    cmd = [
+        str(python),
+        str(verify_script),
+        "--wav",
+        str(wav_path),
+        "--schedule-dir",
+        str(schedule_dir),
+        "--date",
+        "2026-06-20",
+        "--courts",
+        "2,3,4",
+        "--wav-start-time",
+        wav_start,
+        "--by-round",
+    ]
+    print("\nRe-running overhead verification on output wav ...", file=sys.stderr)
+    result = subprocess.run(cmd)
+    return result.returncode
+
+
+def write_injections_sidecar(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/src/scripts/verify_overhead_schedule.py
+++ b/src/scripts/verify_overhead_schedule.py
@@ -1,0 +1,1701 @@
+#!/usr/bin/env python3
+"""
+Verify that a venue-wide overhead .wav aligns with per-court schedule JSONL files.
+
+Builds an expected announcement timeline from the Throw Down PA template
+(measured from BDL Throwdown 5 Full Timeline.wav): court calls, transition
+warnings, play start, halfway, 90s/30s warnings, and countdown within each
+25-minute JSONL slot.
+
+Usage:
+  python verify_overhead_schedule.py \\
+    --wav /path/to/overhead.wav \\
+    --schedule-dir src/output/June2026Tournament/schedule/generated \\
+    --date 2026-06-20 \\
+    --courts 2,3,4 \\
+    --wav-start-time 09:00 \\
+    --timeline-only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import subprocess
+import sys
+import tempfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+COURT_WORDS = {
+    1: ("one", "1"),
+    2: ("two", "2"),
+    3: ("three", "3"),
+    4: ("four", "4"),
+    5: ("five", "5"),
+    6: ("six", "6"),
+}
+
+# Offsets from JSONL slot start_time, derived from BDL Throwdown 5 Full Timeline.wav.
+THROWDOWN_25MIN_MARKERS: list[tuple[str, int, bool, str]] = [
+    ("court_announcement", 0, False, "Court matchup call"),
+    ("transition_2min", 121, True, "Two minutes to get to your next court"),
+    ("transition_1min", 173, True, "One minute to get to your court"),
+    ("transition_30sec", 202, True, "30 seconds to get to your court"),
+    ("play_start", 240, True, "Players line up / here we go"),
+    ("halfway", 780, True, "Halfway through"),
+    ("ninety_seconds", 1235, True, "90 seconds remaining"),
+    ("thirty_seconds", 1294, True, "30 seconds remaining"),
+    ("countdown", 1496, True, "Countdown (10→1 or 9→1)"),
+]
+
+EVENT_CUES: dict[str, list[str]] = {
+    "court_announcement": [
+        r"versus",
+        r"vs\.?",
+        r"home team",
+        r"away team",
+        r"referee",
+    ],
+    "transition_2min": [
+        r"two minutes to get",
+        r"next court",
+    ],
+    "transition_1min": [
+        r"one minute to get",
+        r"your court",
+    ],
+    "transition_30sec": [
+        r"30 seconds to get",
+        r"30 seconds.*court",
+    ],
+    "play_start": [
+        r"players line up",
+        r"here we go",
+    ],
+    "halfway": [
+        r"halfway",
+        r"way through",
+    ],
+    "ninety_seconds": [
+        r"90 seconds",
+        r"ninety seconds",
+    ],
+    "thirty_seconds": [
+        r"30 seconds",
+    ],
+    "countdown": [
+        r"\b10\b.*\b9\b",
+        r"\b9\b.*\b8\b.*\b7\b",
+        r"\b8\b.*\b7\b.*\b6\b",
+        r"five, four",
+        r"four, three",
+        r"\b3, 2, 1\b",
+        r"\b2, 1\b",
+    ],
+}
+
+VENUE_WIDE_EVENTS = {m[0] for m in THROWDOWN_25MIN_MARKERS if m[2]}
+
+VENUE_BUNDLE_CUE_TYPES = [
+    "transition_2min",
+    "transition_1min",
+    "transition_30sec",
+    "play_start",
+    "halfway",
+    "ninety_seconds",
+    "thirty_seconds",
+    "countdown",
+]
+
+_refine_model_cache: dict[str, Any] = {}
+
+
+@dataclass
+class Game:
+    home_team: str
+    away_team: str
+    start_time: str
+    minutes: int
+    court: str
+    court_num: int
+    round: str = ""
+    type: str = ""
+
+
+@dataclass
+class ExpectedEvent:
+    wall_time: str
+    wall_seconds: int
+    wav_offset_seconds: float
+    event_type: str
+    court_num: int
+    court: str
+    home_team: str
+    away_team: str
+    round: str
+    venue_wide: bool = False
+    label: str = ""
+    skipped: bool = False
+    skip_reason: str = ""
+
+
+@dataclass
+class TranscriptSegment:
+    start: float
+    end: float
+    text: str
+
+
+@dataclass
+class MatchResult:
+    expected: ExpectedEvent
+    matched: bool
+    actual_start: float | None = None
+    drift_seconds: float | None = None
+    confidence: float = 0.0
+    matched_text: str = ""
+    status: str = "missed"
+
+
+@dataclass
+class VerificationReport:
+    wav_path: str
+    schedule_date: str
+    wav_start_time: str
+    round_template: str = "throwdown_25min"
+    inferred_wav_start_time: str | None = None
+    wav_duration_seconds: float | None = None
+    tolerance_seconds: int = 90
+    skip_ranges: list[tuple[str, str]] = field(default_factory=list)
+    events: list[dict] = field(default_factory=list)
+    summary: dict = field(default_factory=dict)
+    orphan_segments: list[dict] = field(default_factory=list)
+
+
+def time_to_seconds(time_str: str) -> int:
+    time_str = time_str.strip()
+    if re.match(r"^\d{1,2}:\d{2}:\d{2}$", time_str):
+        h, m, s = (int(x) for x in time_str.split(":"))
+        return h * 3600 + m * 60 + s
+    if re.match(r"^\d{1,2}:\d{2}$", time_str):
+        h, m = (int(x) for x in time_str.split(":"))
+        return h * 3600 + m * 60
+    raise ValueError(f"Invalid time format: {time_str!r}")
+
+
+def seconds_to_hms(total_seconds: float) -> str:
+    total = max(0, int(round(total_seconds)))
+    h = total // 3600
+    m = (total % 3600) // 60
+    s = total % 60
+    return f"{h:02d}:{m:02d}:{s:02d}"
+
+
+def seconds_to_hm(total_seconds: int) -> str:
+    h = total_seconds // 3600
+    m = (total_seconds % 3600) // 60
+    return f"{h:02d}:{m:02d}"
+
+
+def normalize_team(name: str) -> str:
+    text = name.lower().strip()
+    text = re.sub(r"^the\s+", "", text)
+    text = re.sub(r"[^\w\s]", "", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def parse_skip_ranges(ranges: Iterable[str]) -> list[tuple[int, int]]:
+    parsed: list[tuple[int, int]] = []
+    for item in ranges:
+        if "-" not in item:
+            raise ValueError(f"Invalid skip range (expected HH:MM-HH:MM): {item!r}")
+        start_str, end_str = item.split("-", 1)
+        parsed.append((time_to_seconds(start_str.strip()), time_to_seconds(end_str.strip())))
+    return parsed
+
+
+def in_skip_range(wall_seconds: int, skip_ranges: list[tuple[int, int]]) -> bool:
+    for start, end in skip_ranges:
+        if start <= wall_seconds < end:
+            return True
+    return False
+
+
+def load_games(schedule_dir: Path, date: str, courts: list[int]) -> list[Game]:
+    games: list[Game] = []
+    for court_num in courts:
+        jsonl_path = schedule_dir / f"{date}_court{court_num}.jsonl"
+        if not jsonl_path.exists():
+            raise FileNotFoundError(f"Schedule file not found: {jsonl_path}")
+        with jsonl_path.open(encoding="utf-8") as handle:
+            for line_num, line in enumerate(handle, start=1):
+                line = line.strip()
+                if not line:
+                    continue
+                data = json.loads(line)
+                start_time = data["start_time"]
+                if re.match(r"^\d{1,2}:\d{2}:\d{2}$", start_time):
+                    raise ValueError(
+                        f"{jsonl_path}:{line_num}: offset-mode start_time not supported "
+                        f"for overhead verification ({start_time!r})"
+                    )
+                court_label = data.get("court") or f"Court {court_num}"
+                games.append(
+                    Game(
+                        home_team=data["home_team"],
+                        away_team=data["away_team"],
+                        start_time=start_time,
+                        minutes=int(data["minutes"]),
+                        court=court_label,
+                        court_num=court_num,
+                        round=data.get("round", ""),
+                        type=data.get("type", ""),
+                    )
+                )
+    games.sort(key=lambda g: (time_to_seconds(g.start_time), g.court_num))
+    return games
+
+
+def build_expected_events(
+    games: list[Game],
+    wav_start_time: str,
+    skip_ranges: list[tuple[int, int]],
+    skip_before: str | None = None,
+) -> list[ExpectedEvent]:
+    anchor_seconds = time_to_seconds(wav_start_time)
+    skip_before_seconds = time_to_seconds(skip_before) if skip_before else None
+    events: list[ExpectedEvent] = []
+
+    slots: dict[int, list[Game]] = {}
+    for game in games:
+        slots.setdefault(time_to_seconds(game.start_time), []).append(game)
+
+    for slot_start, slot_games in sorted(slots.items()):
+        for event_type, offset, venue_wide, label in THROWDOWN_25MIN_MARKERS:
+            wall_seconds = slot_start + offset
+            skipped = False
+            skip_reason = ""
+            if skip_before_seconds is not None and wall_seconds < skip_before_seconds:
+                skipped = True
+                skip_reason = f"before --skip-before {skip_before}"
+            elif in_skip_range(wall_seconds, skip_ranges):
+                skipped = True
+                skip_reason = "in --skip-ranges"
+
+            if venue_wide:
+                ref = slot_games[0]
+                events.append(
+                    ExpectedEvent(
+                        wall_time=seconds_to_hm(wall_seconds),
+                        wall_seconds=wall_seconds,
+                        wav_offset_seconds=float(wall_seconds - anchor_seconds),
+                        event_type=event_type,
+                        court_num=0,
+                        court="ALL",
+                        home_team="",
+                        away_team="",
+                        round=ref.round,
+                        venue_wide=True,
+                        label=label,
+                        skipped=skipped,
+                        skip_reason=skip_reason,
+                    )
+                )
+                continue
+
+            for game in slot_games:
+                events.append(
+                    ExpectedEvent(
+                        wall_time=seconds_to_hm(wall_seconds),
+                        wall_seconds=wall_seconds,
+                        wav_offset_seconds=float(wall_seconds - anchor_seconds),
+                        event_type=event_type,
+                        court_num=game.court_num,
+                        court=game.court,
+                        home_team=game.home_team,
+                        away_team=game.away_team,
+                        round=game.round,
+                        venue_wide=False,
+                        label=label,
+                        skipped=skipped,
+                        skip_reason=skip_reason,
+                    )
+                )
+
+    events.sort(key=lambda e: (e.wall_seconds, e.venue_wide, e.court_num, e.event_type))
+    return events
+
+
+def group_games_by_slot(games: list[Game]) -> list[tuple[int, list[Game]]]:
+    slots: dict[int, list[Game]] = {}
+    for game in games:
+        slots.setdefault(time_to_seconds(game.start_time), []).append(game)
+    return sorted(slots.items())
+
+
+def build_slot_events(
+    slot_games: list[Game],
+    slot_start_seconds: int,
+    slot_anchor_wav: float,
+    skip_ranges: list[tuple[int, int]],
+    skip_before: str | None = None,
+) -> list[ExpectedEvent]:
+    skip_before_seconds = time_to_seconds(skip_before) if skip_before else None
+    events: list[ExpectedEvent] = []
+
+    for event_type, offset, venue_wide, label in THROWDOWN_25MIN_MARKERS:
+        wall_seconds = slot_start_seconds + offset
+        skipped = False
+        skip_reason = ""
+        if skip_before_seconds is not None and wall_seconds < skip_before_seconds:
+            skipped = True
+            skip_reason = f"before --skip-before {skip_before}"
+        elif in_skip_range(wall_seconds, skip_ranges):
+            skipped = True
+            skip_reason = "in --skip-ranges"
+
+        wav_offset = slot_anchor_wav + offset
+
+        if venue_wide:
+            ref = slot_games[0]
+            events.append(
+                ExpectedEvent(
+                    wall_time=seconds_to_hm(wall_seconds),
+                    wall_seconds=wall_seconds,
+                    wav_offset_seconds=wav_offset,
+                    event_type=event_type,
+                    court_num=0,
+                    court="ALL",
+                    home_team="",
+                    away_team="",
+                    round=ref.round,
+                    venue_wide=True,
+                    label=label,
+                    skipped=skipped,
+                    skip_reason=skip_reason,
+                )
+            )
+            continue
+
+        for game in slot_games:
+            events.append(
+                ExpectedEvent(
+                    wall_time=seconds_to_hm(wall_seconds),
+                    wall_seconds=wall_seconds,
+                    wav_offset_seconds=wav_offset,
+                    event_type=event_type,
+                    court_num=game.court_num,
+                    court=game.court,
+                    home_team=game.home_team,
+                    away_team=game.away_team,
+                    round=game.round,
+                    venue_wide=False,
+                    label=label,
+                    skipped=skipped,
+                    skip_reason=skip_reason,
+                )
+            )
+
+    events.sort(key=lambda e: (e.venue_wide, e.court_num, e.event_type))
+    return events
+
+
+def infer_slot_anchor_wav(
+    slot_games: list[Game],
+    segments: list[TranscriptSegment],
+    hint_wav: float,
+    tolerance: int,
+    min_confidence: float,
+) -> float | None:
+    search_start = max(0, hint_wav - tolerance * 2)
+    search_end = hint_wav + tolerance * 2 + 300
+
+    for offset, pattern in [
+        (240, r"here we go|players line up"),
+        (0, r"versus|vs\.?|home team"),
+    ]:
+        target = hint_wav + offset
+        best_start: float | None = None
+        best_score = 0.0
+        for segment in segments:
+            if segment.start < search_start or segment.start > search_end:
+                continue
+            if abs(segment.start - target) > tolerance * 2 + (120 if offset == 0 else 60):
+                continue
+            text = segment.text.lower()
+            if not re.search(pattern, text):
+                continue
+            if offset == 240:
+                return segment.start - 240
+            for game in slot_games:
+                probe = ExpectedEvent(
+                    wall_time="",
+                    wall_seconds=0,
+                    wav_offset_seconds=0,
+                    event_type="court_announcement",
+                    court_num=game.court_num,
+                    court=game.court,
+                    home_team=game.home_team,
+                    away_team=game.away_team,
+                    round=game.round,
+                )
+                score = score_segment(probe, segment)
+                if score >= min_confidence and score > best_score:
+                    best_score = score
+                    best_start = segment.start
+        if best_start is not None:
+            return best_start
+
+    return None
+
+
+def match_slot_events(
+    events: list[ExpectedEvent],
+    segments: list[TranscriptSegment],
+    tolerance: int,
+    min_confidence: float,
+) -> list[MatchResult]:
+    results: list[MatchResult] = []
+    used_venue_segments: set[int] = set()
+
+    court_events = [e for e in events if e.event_type == "court_announcement" and not e.skipped]
+    venue_events = [e for e in events if e.event_type != "court_announcement"]
+
+    for event in court_events:
+        if event.skipped:
+            results.append(MatchResult(expected=event, matched=False, status="skipped"))
+            continue
+        window_start = max(0, event.wav_offset_seconds - tolerance)
+        window_end = event.wav_offset_seconds + tolerance + 120
+
+        best_idx: int | None = None
+        best_score = 0.0
+        for idx, segment in enumerate(segments):
+            if segment.start < window_start or segment.start > window_end:
+                continue
+            score = score_segment(event, segment)
+            if score > best_score:
+                best_score = score
+                best_idx = idx
+
+        if best_idx is None or best_score < min_confidence:
+            results.append(
+                MatchResult(expected=event, matched=False, confidence=best_score, status="missed")
+            )
+            continue
+
+        segment = segments[best_idx]
+        results.append(
+            MatchResult(
+                expected=event,
+                matched=True,
+                actual_start=segment.start,
+                drift_seconds=segment.start - event.wav_offset_seconds,
+                confidence=best_score,
+                matched_text=segment.text.strip(),
+                status="matched",
+            )
+        )
+
+    for event in venue_events:
+        if event.skipped:
+            results.append(MatchResult(expected=event, matched=False, status="skipped"))
+            continue
+
+        threshold = 0.35
+        window_start = event.wav_offset_seconds - tolerance
+        window_end = event.wav_offset_seconds + tolerance
+
+        best_idx: int | None = None
+        best_score = 0.0
+        for idx, segment in enumerate(segments):
+            if idx in used_venue_segments:
+                continue
+            if segment.start < window_start or segment.start > window_end:
+                continue
+            score = score_segment(event, segment)
+            if score > best_score:
+                best_score = score
+                best_idx = idx
+
+        if best_idx is None or best_score < threshold:
+            results.append(
+                MatchResult(
+                    expected=event,
+                    matched=False,
+                    confidence=best_score,
+                    status="missed",
+                )
+            )
+            continue
+
+        segment = segments[best_idx]
+        used_venue_segments.add(best_idx)
+        results.append(
+            MatchResult(
+                expected=event,
+                matched=True,
+                actual_start=segment.start,
+                drift_seconds=segment.start - event.wav_offset_seconds,
+                confidence=best_score,
+                matched_text=segment.text.strip(),
+                status="matched",
+            )
+        )
+
+    results.sort(
+        key=lambda r: (
+            r.expected.venue_wide,
+            r.expected.court_num,
+            r.expected.event_type,
+        )
+    )
+    return results
+
+
+def format_anchor_offset(offset_seconds: float) -> str:
+    sign = "+" if offset_seconds >= 0 else "-"
+    rel_m, rel_s = divmod(abs(int(round(offset_seconds))), 60)
+    return f"{sign}{rel_m}:{rel_s:02d}"
+
+
+def collect_slot_speech(
+    segments: list[TranscriptSegment],
+    slot_anchor: float,
+    wav_start_seconds: int,
+    pre_seconds: int = 30,
+    post_seconds: int = 26 * 60,
+) -> list[dict]:
+    window_start = slot_anchor - pre_seconds
+    window_end = slot_anchor + post_seconds
+    items: list[dict] = []
+
+    for segment in segments:
+        if segment.start < window_start or segment.start > window_end:
+            continue
+        text = segment.text.strip()
+        if not text:
+            continue
+        offset = segment.start - slot_anchor
+        wall_seconds = wav_start_seconds + int(segment.start)
+        items.append(
+            {
+                "wav_seconds": round(segment.start, 2),
+                "wav_timestamp": seconds_to_hms(segment.start),
+                "wall_time": seconds_to_hm(wall_seconds),
+                "offset_seconds": round(offset, 1),
+                "offset": format_anchor_offset(offset),
+                "text": text,
+                "cues": venue_cues_in_text(text),
+            }
+        )
+
+    items.sort(key=lambda item: item["wav_seconds"])
+    return items
+
+
+def print_slot_transcript(
+    speech_items: list[dict],
+) -> None:
+    print("  --- exact phrases in audio ---")
+    if not speech_items:
+        print("  (no speech detected in this window)")
+    else:
+        for item in speech_items:
+            cue_str = f"  [{', '.join(item['cues'])}]" if item["cues"] else ""
+            print(
+                f"  {item['wav_timestamp']}  ({item['offset']}){cue_str}  {item['text']}"
+            )
+    print()
+
+
+def serialize_refinements(refinements: list[dict], wav_start_seconds: int, slot_anchor: float) -> list[dict]:
+    serialized: list[dict] = []
+    for item in refinements:
+        refined_speech = collect_slot_speech(
+            item["refined"],
+            slot_anchor=slot_anchor,
+            wav_start_seconds=wav_start_seconds,
+            pre_seconds=0,
+            post_seconds=26 * 60,
+        )
+        serialized.append(
+            {
+                "original_wav_seconds": round(item["original_start"], 2),
+                "original_wav_timestamp": seconds_to_hms(item["original_start"]),
+                "original_text": item["original_text"],
+                "bundled_cues": item["cues"],
+                "refined": refined_speech,
+            }
+        )
+    return serialized
+
+
+def serialize_match_results(results: list[MatchResult]) -> list[dict]:
+    serialized: list[dict] = []
+    for result in results:
+        serialized.append(
+            {
+                "expected": asdict(result.expected),
+                "matched": result.matched,
+                "actual_start": result.actual_start,
+                "actual_wav_timestamp": (
+                    seconds_to_hms(result.actual_start) if result.actual_start is not None else None
+                ),
+                "drift_seconds": result.drift_seconds,
+                "confidence": round(result.confidence, 3),
+                "matched_text": result.matched_text,
+                "status": result.status,
+            }
+        )
+    return serialized
+
+
+def write_by_round_phrases_file(reports: list[dict], output_path: Path) -> None:
+    lines: list[str] = []
+    for report in reports:
+        lines.append(
+            f"Round {report['round']} ({report['schedule_label']}, wall {report['wall_start']})  "
+            f"anchor {seconds_to_hms(report['slot_anchor_wav'])}"
+        )
+        lines.append(f"{'WAV':<12} {'OFFSET':<8} {'WALL':<8} {'TEXT'}")
+        lines.append("-" * 90)
+        for item in report["speech"]:
+            cue_note = f"  [{', '.join(item['cues'])}]" if item["cues"] else ""
+            lines.append(
+                f"{item['wav_timestamp']:<12} {item['offset']:<8} {item['wall_time']:<8} "
+                f"{item['text']}{cue_note}"
+            )
+        lines.append("")
+    output_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def write_by_round_report(
+    reports: list[dict],
+    output_path: Path,
+    wav_path: Path,
+    wav_start_time: str,
+    tolerance: int,
+    refine_bundled: bool,
+) -> None:
+    passed = sum(1 for report in reports if report["summary"]["match_rate"] >= 0.8)
+    payload = {
+        "wav_path": str(wav_path),
+        "wav_start_time": wav_start_time,
+        "mode": "by_round",
+        "tolerance_seconds": tolerance,
+        "refine_bundled": refine_bundled,
+        "rounds_passed": passed,
+        "rounds_total": len(reports),
+        "rounds": [
+            {
+                "round": report["round"],
+                "schedule_label": report["schedule_label"],
+                "wall_start": report["wall_start"],
+                "slot_anchor_wav_seconds": report["slot_anchor_wav"],
+                "slot_anchor_wav_timestamp": seconds_to_hms(report["slot_anchor_wav"]),
+                "anchor_source": report["anchor_source"],
+                "schedule_hint_wav_seconds": report["schedule_hint_wav"],
+                "anchor_drift_seconds": report["anchor_drift"],
+                "bundled_segments_refined": report["bundled_segments_refined"],
+                "matchups": report["matchups"],
+                "summary": report["summary"],
+                "speech": report["speech"],
+                "refined_bundles": report.get("refined_bundles", []),
+                "matches": report["matches"],
+            }
+            for report in reports
+        ],
+    }
+    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"By-round report: {output_path}", file=sys.stderr)
+
+
+def verify_by_round(
+    games: list[Game],
+    segments: list[TranscriptSegment],
+    wav_path: Path,
+    wav_start_time: str,
+    tolerance: int,
+    min_confidence: float,
+    skip_ranges: list[tuple[int, int]],
+    skip_before: str | None,
+    refine_bundled: bool = True,
+    refine_model: str = "base",
+    refine_chunk_sec: int = 8,
+    refine_cache: dict | None = None,
+    round_filter: int | None = None,
+    verbose: bool = False,
+) -> list[dict]:
+    global_anchor = time_to_seconds(wav_start_time)
+    round_reports: list[dict] = []
+
+    for round_idx, (slot_start, slot_games) in enumerate(group_games_by_slot(games), start=1):
+        if round_filter is not None and round_idx != round_filter:
+            continue
+
+        slot_games.sort(key=lambda g: g.court_num)
+        ref = slot_games[0]
+        hint_wav = float(slot_start - global_anchor)
+        slot_anchor = infer_slot_anchor_wav(
+            slot_games, segments, hint_wav, tolerance, min_confidence
+        )
+        anchor_source = "inferred"
+        if slot_anchor is None:
+            slot_anchor = hint_wav
+            anchor_source = "schedule_hint"
+
+        events = build_slot_events(
+            slot_games, slot_start, slot_anchor, skip_ranges, skip_before
+        )
+        slot_segments = segments
+        refinements: list[dict] = []
+        if refine_bundled:
+            slot_segments, refinements = augment_slot_segments(
+                segments,
+                slot_anchor,
+                wav_path,
+                refine_model,
+                refine_chunk_sec,
+                refine_cache,
+            )
+
+        results = match_slot_events(events, slot_segments, tolerance, min_confidence)
+        summary = build_summary(results, sorted({g.court_num for g in slot_games}))
+        speech = collect_slot_speech(
+            slot_segments,
+            slot_anchor,
+            global_anchor,
+        )
+        refined_bundles = serialize_refinements(refinements, global_anchor, slot_anchor)
+
+        report = {
+            "round": round_idx,
+            "schedule_label": ref.round,
+            "wall_start": seconds_to_hm(slot_start),
+            "slot_anchor_wav": round(slot_anchor, 1),
+            "anchor_source": anchor_source,
+            "schedule_hint_wav": hint_wav,
+            "anchor_drift": round(slot_anchor - hint_wav, 1),
+            "bundled_segments_refined": len(refinements),
+            "matchups": {
+                g.court_num: f"{g.home_team} vs {g.away_team}" for g in slot_games
+            },
+            "summary": summary,
+            "speech": speech,
+            "refined_bundles": refined_bundles,
+            "matches": serialize_match_results(results),
+            "results": results,
+        }
+        round_reports.append(report)
+
+        status = "PASS" if summary["match_rate"] >= 0.8 else "FAIL"
+        print(
+            f"Round {round_idx:2d} ({ref.round}, {seconds_to_hm(slot_start)})  "
+            f"anchor {seconds_to_hms(slot_anchor)} ({anchor_source}, drift {slot_anchor - hint_wav:+.0f}s)  "
+            f"{summary['matched']}/{summary['total_events']} matched ({summary['match_rate']:.0%})  {status}"
+        )
+
+        if verbose or round_filter is not None:
+            print(f"  Matchups: " + ", ".join(
+                f"C{n} {m}" for n, m in sorted(report["matchups"].items())
+            ))
+            print_slot_transcript(speech)
+            if refinements:
+                print_refined_bundles(refinements, refine_chunk_sec)
+            for result in results:
+                event = result.expected
+                if result.status in ("skipped",):
+                    continue
+                court = "ALL" if event.venue_wide else f"C{event.court_num}"
+                if result.matched:
+                    drift = f"{result.drift_seconds:+.0f}s"
+                    print(
+                        f"  {event.event_type:<20} {court:<4} "
+                        f"{seconds_to_hms(result.actual_start)} ({drift})  {result.matched_text.strip()}"
+                    )
+                else:
+                    print(f"  {event.event_type:<20} {court:<4}  MISSED")
+            print()
+
+    return round_reports
+
+
+def court_regex(court_num: int) -> re.Pattern[str]:
+    word, digit = COURT_WORDS.get(court_num, (str(court_num), str(court_num)))
+    return re.compile(rf"\bcourt\s*(?:{word}|{digit})\b", re.I)
+
+
+def score_segment(event: ExpectedEvent, segment: TranscriptSegment) -> float:
+    try:
+        from rapidfuzz import fuzz
+    except ImportError:
+        print(
+            "Error: rapidfuzz is required. Install with: pip install -r requirements-transcribe.txt",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    text = segment.text.lower()
+    cue_patterns = EVENT_CUES.get(event.event_type, [])
+    cue_hits = sum(1 for pattern in cue_patterns if re.search(pattern, text, re.I))
+
+    if event.venue_wide:
+        if cue_hits == 0:
+            return 0.0
+        return min(0.5 + 0.15 * cue_hits, 1.0)
+
+    score = 0.0
+    if court_regex(event.court_num).search(text):
+        score += 0.35
+
+    home_norm = normalize_team(event.home_team)
+    away_norm = normalize_team(event.away_team)
+    score += 0.25 * (fuzz.partial_ratio(home_norm, text) / 100.0)
+    score += 0.25 * (fuzz.partial_ratio(away_norm, text) / 100.0)
+
+    if cue_hits:
+        score += min(0.25, 0.1 * cue_hits)
+
+    return min(score, 1.0)
+
+
+def match_events_to_transcript(
+    events: list[ExpectedEvent],
+    segments: list[TranscriptSegment],
+    tolerance: int,
+    min_confidence: float,
+) -> list[MatchResult]:
+    results: list[MatchResult] = []
+    used_segment_indices: set[int] = set()
+
+    for event in events:
+        if event.skipped:
+            results.append(MatchResult(expected=event, matched=False, status="skipped"))
+            continue
+
+        if event.wav_offset_seconds < 0:
+            results.append(MatchResult(expected=event, matched=False, status="before_wav_start"))
+            continue
+
+        threshold = 0.35 if event.venue_wide else min_confidence
+        window_start = event.wav_offset_seconds - tolerance
+        window_end = event.wav_offset_seconds + tolerance
+
+        best_idx: int | None = None
+        best_score = 0.0
+        for idx, segment in enumerate(segments):
+            if idx in used_segment_indices:
+                continue
+            if segment.start < window_start or segment.start > window_end:
+                continue
+            score = score_segment(event, segment)
+            if score > best_score:
+                best_score = score
+                best_idx = idx
+
+        if best_idx is None or best_score < threshold:
+            results.append(
+                MatchResult(
+                    expected=event,
+                    matched=False,
+                    confidence=best_score,
+                    status="missed",
+                )
+            )
+            continue
+
+        segment = segments[best_idx]
+        used_segment_indices.add(best_idx)
+        drift = segment.start - event.wav_offset_seconds
+        results.append(
+            MatchResult(
+                expected=event,
+                matched=True,
+                actual_start=segment.start,
+                drift_seconds=drift,
+                confidence=best_score,
+                matched_text=segment.text.strip(),
+                status="matched",
+            )
+        )
+
+    return results
+
+
+def infer_wav_start_time(
+    events: list[ExpectedEvent],
+    segments: list[TranscriptSegment],
+    tolerance: int,
+    min_confidence: float,
+) -> str | None:
+    start_events = [
+        e for e in events if e.event_type == "court_announcement" and not e.skipped
+    ]
+    if not start_events or not segments:
+        return None
+
+    best_anchor: int | None = None
+    best_score = 0.0
+
+    for event in start_events[:12]:
+        for segment in segments:
+            if segment.start > 3600:
+                break
+            score = score_segment(event, segment)
+            if score >= min_confidence and score > best_score:
+                inferred_anchor = event.wall_seconds - int(round(segment.start))
+                best_score = score
+                best_anchor = inferred_anchor
+
+    if best_anchor is None:
+        return None
+    return seconds_to_hm(best_anchor)
+
+
+def get_wav_duration(wav_path: Path) -> float:
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        str(wav_path),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return float(result.stdout.strip())
+
+
+def transcribe_wav(
+    wav_path: Path,
+    model_name: str,
+    cache_path: Path | None,
+    force_retranscribe: bool,
+) -> list[TranscriptSegment]:
+    if cache_path and cache_path.exists() and not force_retranscribe:
+        data = json.loads(cache_path.read_text(encoding="utf-8"))
+        return [TranscriptSegment(**item) for item in data["segments"]]
+
+    try:
+        from faster_whisper import WhisperModel
+    except ImportError:
+        print(
+            "Error: faster-whisper is required. Install with: pip install -r requirements-transcribe.txt",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(f"Transcribing {wav_path} with model={model_name} ...", file=sys.stderr)
+    model = WhisperModel(model_name, device="cpu", compute_type="int8")
+    segments_iter, _info = model.transcribe(str(wav_path), vad_filter=True)
+
+    segments: list[TranscriptSegment] = []
+    for segment in segments_iter:
+        text = segment.text.strip()
+        if text:
+            segments.append(
+                TranscriptSegment(start=segment.start, end=segment.end, text=text)
+            )
+
+    if cache_path:
+        cache_path.write_text(
+            json.dumps(
+                {
+                    "wav_path": str(wav_path),
+                    "model": model_name,
+                    "segments": [asdict(s) for s in segments],
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        print(f"Cached transcript: {cache_path}", file=sys.stderr)
+
+    return segments
+
+
+def venue_cues_in_text(text: str) -> list[str]:
+    text_lower = text.lower()
+    hits: list[str] = []
+    for event_type in VENUE_BUNDLE_CUE_TYPES:
+        patterns = EVENT_CUES.get(event_type, [])
+        if any(re.search(pattern, text_lower, re.I) for pattern in patterns):
+            hits.append(event_type)
+    return hits
+
+
+def is_bundled_segment(segment: TranscriptSegment) -> bool:
+    hits = venue_cues_in_text(segment.text)
+    if len(set(hits)) >= 2:
+        return True
+    return bool(hits and len(segment.text) > 120)
+
+
+def get_refinement_model(model_name: str) -> Any:
+    if model_name not in _refine_model_cache:
+        try:
+            from faster_whisper import WhisperModel
+        except ImportError:
+            print(
+                "Error: faster-whisper is required. Install with: pip install -r requirements-transcribe.txt",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(f"Loading bundled-cue refinement model={model_name} ...", file=sys.stderr)
+        _refine_model_cache[model_name] = WhisperModel(
+            model_name, device="cpu", compute_type="int8"
+        )
+    return _refine_model_cache[model_name]
+
+
+def load_refinement_cache(path: Path | None) -> dict:
+    if path and path.exists():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return {"chunk_sec": None, "refine_model": None, "entries": {}}
+
+
+def save_refinement_cache(path: Path | None, data: dict) -> None:
+    if path:
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def refine_bundled_segment(
+    wav_path: Path,
+    segment: TranscriptSegment,
+    model: Any,
+    chunk_sec: int,
+    workdir: Path,
+) -> list[TranscriptSegment]:
+    start = max(0.0, segment.start - 1.0)
+    end = max(segment.end, segment.start + 2.0)
+    duration = max(end - start, 3.0)
+
+    clip = workdir / f"clip_{int(segment.start * 10)}.wav"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-ss",
+            str(start),
+            "-t",
+            str(duration),
+            "-i",
+            str(wav_path),
+            "-ac",
+            "1",
+            "-ar",
+            "16000",
+            str(clip),
+        ],
+        capture_output=True,
+        check=True,
+    )
+
+    refined: list[TranscriptSegment] = []
+    sub_starts = list(range(0, int(duration), chunk_sec)) if duration > chunk_sec else [0]
+
+    for sub_off in sub_starts:
+        sub_dur = min(float(chunk_sec), duration - sub_off)
+        if sub_dur < 1.5:
+            continue
+        sub_clip = workdir / f"sub_{int(segment.start * 10)}_{sub_off}.wav"
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-ss",
+                str(sub_off),
+                "-t",
+                str(sub_dur),
+                "-i",
+                str(clip),
+                "-ac",
+                "1",
+                "-ar",
+                "16000",
+                str(sub_clip),
+            ],
+            capture_output=True,
+            check=True,
+        )
+        segments_iter, _info = model.transcribe(str(sub_clip), vad_filter=True)
+        for piece in segments_iter:
+            text = piece.text.strip()
+            if not text:
+                continue
+            abs_start = start + sub_off + piece.start
+            abs_end = start + sub_off + piece.end
+            refined.append(TranscriptSegment(start=abs_start, end=abs_end, text=text))
+
+    return refined
+
+
+def augment_slot_segments(
+    segments: list[TranscriptSegment],
+    slot_anchor: float,
+    wav_path: Path,
+    refine_model: str,
+    chunk_sec: int,
+    refine_cache: dict | None,
+    pre_seconds: int = 30,
+    post_seconds: int = 26 * 60,
+) -> tuple[list[TranscriptSegment], list[dict]]:
+    window_start = slot_anchor - pre_seconds
+    window_end = slot_anchor + post_seconds
+
+    bundled_indices = [
+        idx
+        for idx, segment in enumerate(segments)
+        if window_start <= segment.start <= window_end and is_bundled_segment(segment)
+    ]
+    if not bundled_indices:
+        return segments, []
+
+    model = get_refinement_model(refine_model)
+    cache_entries = refine_cache.setdefault("entries", {}) if refine_cache is not None else {}
+    refinements: list[dict] = []
+
+    with tempfile.TemporaryDirectory(prefix="overhead_refine_") as tmp:
+        workdir = Path(tmp)
+        for idx in bundled_indices:
+            segment = segments[idx]
+            cache_key = f"{segment.start:.1f}"
+            if refine_cache is not None and cache_key in cache_entries:
+                refined = [
+                    TranscriptSegment(**item) for item in cache_entries[cache_key]["segments"]
+                ]
+            else:
+                refined = refine_bundled_segment(
+                    wav_path, segment, model, chunk_sec, workdir
+                )
+                if refine_cache is not None:
+                    cache_entries[cache_key] = {
+                        "original_text": segment.text,
+                        "segments": [asdict(item) for item in refined],
+                    }
+
+            refinements.append(
+                {
+                    "original_start": segment.start,
+                    "original_text": segment.text.strip(),
+                    "cues": venue_cues_in_text(segment.text),
+                    "refined": refined,
+                }
+            )
+
+    if refine_cache is not None:
+        refine_cache["chunk_sec"] = chunk_sec
+        refine_cache["refine_model"] = refine_model
+
+    bundled_set = set(bundled_indices)
+    merged = [segment for idx, segment in enumerate(segments) if idx not in bundled_set]
+    for item in refinements:
+        merged.extend(item["refined"])
+    merged.sort(key=lambda segment: segment.start)
+    return merged, refinements
+
+
+def print_refined_bundles(refinements: list[dict], chunk_sec: int) -> None:
+    if not refinements:
+        return
+    print(f"  --- refined bundled cues ({chunk_sec}s sub-chunks) ---")
+    for item in refinements:
+        cue_label = ", ".join(item["cues"]) if item["cues"] else "?"
+        print(
+            f"  {seconds_to_hms(item['original_start'])}  "
+            f"(was bundled: {cue_label})"
+        )
+        print(f"    ORIG: {item['original_text'][:100]}{'…' if len(item['original_text']) > 100 else ''}")
+        for segment in item["refined"]:
+            cues = venue_cues_in_text(segment.text)
+            cue_str = f" [{', '.join(cues)}]" if cues else ""
+            print(f"    {seconds_to_hms(segment.start)}{cue_str}  {segment.text.strip()}")
+    print()
+
+
+def find_orphan_segments(
+    segments: list[TranscriptSegment],
+    results: list[MatchResult],
+) -> list[dict]:
+    matched_texts = {r.matched_text.lower() for r in results if r.matched and r.matched_text}
+    orphans: list[dict] = []
+    for segment in segments:
+        text_lower = segment.text.lower()
+        if text_lower in matched_texts:
+            continue
+        if not re.search(
+            r"\b(court\s*(?:one|two|three|four|[1-4])|halfway|here we go|seconds remaining|countdown)\b",
+            text_lower,
+        ):
+            continue
+        orphans.append(
+            {
+                "start": segment.start,
+                "start_hms": seconds_to_hms(segment.start),
+                "text": segment.text.strip(),
+            }
+        )
+    return orphans
+
+
+def build_summary(results: list[MatchResult], courts: list[int]) -> dict:
+    active = [r for r in results if r.status not in ("skipped", "before_wav_start")]
+    matched = [r for r in active if r.matched]
+    missed = [r for r in active if not r.matched]
+    drifts = [abs(r.drift_seconds) for r in matched if r.drift_seconds is not None]
+
+    per_court: dict[str, dict] = {}
+    for court_num in courts:
+        court_results = [
+            r for r in active if not r.expected.venue_wide and r.expected.court_num == court_num
+        ]
+        court_matched = [r for r in court_results if r.matched]
+        per_court[str(court_num)] = {
+            "total": len(court_results),
+            "matched": len(court_matched),
+            "missed": len(court_results) - len(court_matched),
+        }
+
+    venue_results = [r for r in active if r.expected.venue_wide]
+    venue_matched = [r for r in venue_results if r.matched]
+
+    match_rate = (len(matched) / len(active)) if active else 0.0
+    return {
+        "total_events": len(active),
+        "matched": len(matched),
+        "missed": len(missed),
+        "skipped": len([r for r in results if r.status == "skipped"]),
+        "before_wav_start": len([r for r in results if r.status == "before_wav_start"]),
+        "match_rate": round(match_rate, 3),
+        "max_drift_seconds": round(max(drifts), 1) if drifts else None,
+        "median_drift_seconds": round(statistics.median(drifts), 1) if drifts else None,
+        "venue_wide": {
+            "total": len(venue_results),
+            "matched": len(venue_matched),
+            "missed": len(venue_results) - len(venue_matched),
+        },
+        "per_court": per_court,
+        "missed_events": [
+            {
+                "wall_time": r.expected.wall_time,
+                "court": r.expected.court,
+                "event_type": r.expected.event_type,
+                "label": r.expected.label,
+                "home_team": r.expected.home_team,
+                "away_team": r.expected.away_team,
+                "round": r.expected.round,
+                "confidence": round(r.confidence, 3),
+            }
+            for r in missed
+        ],
+    }
+
+
+def print_timeline(events: list[ExpectedEvent], wav_start_time: str) -> None:
+    print(f"Expected announcement timeline (wav anchor: {wav_start_time}, throwdown_25min template)")
+    print(f"{'WALL':<8} {'WAV':<10} {'COURT':<8} {'TYPE':<20} {'DETAIL'}")
+    print("-" * 90)
+    for event in events:
+        if event.skipped:
+            marker = f" [skipped: {event.skip_reason}]"
+        elif event.wav_offset_seconds < 0:
+            marker = " [before wav start]"
+        else:
+            marker = ""
+        court = "ALL" if event.venue_wide else str(event.court_num)
+        detail = event.label if event.venue_wide else f"{event.home_team} vs {event.away_team}"
+        print(
+            f"{event.wall_time:<8} "
+            f"{seconds_to_hms(event.wav_offset_seconds):<10} "
+            f"{court:<8} "
+            f"{event.event_type:<20} "
+            f"{detail}{marker}"
+        )
+
+
+def print_results_table(results: list[MatchResult]) -> None:
+    print()
+    print(f"{'EXPECTED':<22} {'WAV':<10} {'DRIFT':<8} {'CONF':<6} {'STATUS':<10} MATCH")
+    print("-" * 110)
+    for result in results:
+        event = result.expected
+        court = "ALL" if event.venue_wide else f"C{event.court_num}"
+        label = f"{event.wall_time} {court} {event.event_type[:8]}"
+        if result.status in ("skipped", "before_wav_start"):
+            print(f"{label:<22} {'—':<10} {'—':<8} {'—':<6} {result.status:<10}")
+            continue
+        wav = seconds_to_hms(result.actual_start) if result.actual_start is not None else "—"
+        drift = f"{result.drift_seconds:+.0f}s" if result.drift_seconds is not None else "—"
+        conf = f"{result.confidence:.2f}" if result.confidence else "—"
+        snippet = result.matched_text[:60] + ("…" if len(result.matched_text) > 60 else "")
+        print(f"{label:<22} {wav:<10} {drift:<8} {conf:<6} {result.status:<10} {snippet}")
+
+
+def write_report(report: VerificationReport, output_path: Path) -> None:
+    output_path.write_text(json.dumps(asdict(report), indent=2), encoding="utf-8")
+    print(f"\nReport written: {output_path}", file=sys.stderr)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify overhead .wav announcements against schedule JSONL files."
+    )
+    parser.add_argument("--wav", type=Path, required=True, help="Path to venue-wide overhead .wav")
+    parser.add_argument(
+        "--schedule-dir",
+        type=Path,
+        required=True,
+        help="Directory containing {date}_courtN.jsonl files",
+    )
+    parser.add_argument("--date", required=True, help="Schedule date (YYYY-MM-DD)")
+    parser.add_argument(
+        "--courts",
+        default="2,3,4",
+        help="Comma-separated court numbers to include (default: 2,3,4)",
+    )
+    parser.add_argument(
+        "--wav-start-time",
+        help="Wall-clock time when .wav offset 0:00 begins (HH:MM). Omit to auto-infer.",
+    )
+    parser.add_argument(
+        "--tolerance",
+        type=int,
+        default=90,
+        help="Search window +/- seconds around expected wav offset (default: 90)",
+    )
+    parser.add_argument(
+        "--min-confidence",
+        type=float,
+        default=0.55,
+        help="Minimum match score for court announcements (default: 0.55)",
+    )
+    parser.add_argument(
+        "--match-rate-threshold",
+        type=float,
+        default=0.80,
+        help="Required match rate for exit code 0 (default: 0.80)",
+    )
+    parser.add_argument(
+        "--max-drift",
+        type=int,
+        default=120,
+        help="Maximum allowed abs drift in seconds for exit code 0 (default: 120)",
+    )
+    parser.add_argument(
+        "--skip-ranges",
+        action="append",
+        default=[],
+        help="Wall-clock ranges to skip, e.g. 12:05-13:30 (repeatable)",
+    )
+    parser.add_argument(
+        "--skip-before",
+        help="Skip events before this wall-clock time (HH:MM), e.g. afternoon bracket only",
+    )
+    parser.add_argument(
+        "--model",
+        default="small",
+        help="faster-whisper model size (default: small)",
+    )
+    parser.add_argument(
+        "--transcript-cache",
+        type=Path,
+        help="Path to transcript JSON cache (default: {wav}.transcript.json)",
+    )
+    parser.add_argument(
+        "--retranscribe",
+        action="store_true",
+        help="Ignore cached transcript and re-run whisper",
+    )
+    parser.add_argument(
+        "--output-report",
+        type=Path,
+        help="Write JSON report to this path (default: beside .wav)",
+    )
+    parser.add_argument(
+        "--timeline-only",
+        action="store_true",
+        help="Print expected timeline only; do not transcribe",
+    )
+    parser.add_argument(
+        "--by-round",
+        action="store_true",
+        help="Verify each schedule round independently with per-slot audio anchoring",
+    )
+    parser.add_argument(
+        "--round",
+        type=int,
+        metavar="N",
+        help="With --by-round, show full detail for round N only (1-based)",
+    )
+    parser.add_argument(
+        "--no-refine-bundled",
+        action="store_true",
+        help="With --by-round, skip 8s-chunk re-transcription of bundled Whisper segments",
+    )
+    parser.add_argument(
+        "--refine-model",
+        default="base",
+        help="faster-whisper model for bundled-cue refinement (default: base)",
+    )
+    parser.add_argument(
+        "--refine-chunk-sec",
+        type=int,
+        default=8,
+        help="Sub-chunk size in seconds for bundled-cue refinement (default: 8)",
+    )
+    parser.add_argument(
+        "--refine-cache",
+        type=Path,
+        help="Cache refined bundled segments (default: {transcript}.refined.json)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    if not args.timeline_only and not args.wav.exists():
+        print(f"Error: WAV file not found: {args.wav}", file=sys.stderr)
+        return 1
+
+    courts = [int(c.strip()) for c in args.courts.split(",") if c.strip()]
+    skip_ranges = parse_skip_ranges(args.skip_ranges)
+
+    try:
+        games = load_games(args.schedule_dir, args.date, courts)
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    wav_start_time = args.wav_start_time
+    if args.timeline_only and not wav_start_time:
+        print("Error: --timeline-only requires --wav-start-time", file=sys.stderr)
+        return 1
+
+    if not wav_start_time:
+        wav_start_time = "09:00"
+        print(
+            f"Warning: --wav-start-time not set; using {wav_start_time} for initial pass "
+            "(will auto-infer if possible)",
+            file=sys.stderr,
+        )
+
+    events = build_expected_events(
+        games,
+        wav_start_time=wav_start_time,
+        skip_ranges=skip_ranges,
+        skip_before=args.skip_before,
+    )
+
+    if args.timeline_only:
+        print_timeline(events, wav_start_time)
+        return 0
+
+    cache_path = args.transcript_cache or args.wav.with_suffix(args.wav.suffix + ".transcript.json")
+
+    if args.by_round:
+        if not cache_path.exists() and not args.wav.exists():
+            print(f"Error: WAV file not found: {args.wav}", file=sys.stderr)
+            return 1
+        segments = transcribe_wav(args.wav, args.model, cache_path, args.retranscribe)
+        if not wav_start_time:
+            print("Error: --by-round requires --wav-start-time", file=sys.stderr)
+            return 1
+        print(
+            f"Per-round verification (tolerance ±{args.tolerance}s, full phrases"
+            f"{'' if args.no_refine_bundled else ', bundled-cue refinement'})"
+            f"\n{'RND':<4} {'SCHEDULE':<12} {'WALL':<6} {'ANCHOR':<10} {'DRIFT':<8} {'MATCHED':<12} {'STATUS'}"
+        )
+        print("-" * 72)
+        refine_cache_path = args.refine_cache or cache_path.with_name(
+            f"{cache_path.stem}.refined.json"
+        )
+        refine_cache = load_refinement_cache(refine_cache_path)
+        reports = verify_by_round(
+            games,
+            segments,
+            args.wav,
+            wav_start_time,
+            args.tolerance,
+            args.min_confidence,
+            skip_ranges,
+            args.skip_before,
+            refine_bundled=not args.no_refine_bundled,
+            refine_model=args.refine_model,
+            refine_chunk_sec=args.refine_chunk_sec,
+            refine_cache=refine_cache if not args.no_refine_bundled else None,
+            round_filter=args.round,
+            verbose=True,
+        )
+        if not args.no_refine_bundled:
+            save_refinement_cache(refine_cache_path, refine_cache)
+            print(f"Refinement cache: {refine_cache_path}", file=sys.stderr)
+        if not reports:
+            print("No rounds matched filter.", file=sys.stderr)
+            return 1
+        output_report = args.output_report or args.wav.with_name(
+            f"{args.wav.stem}_overhead_by_round_report.json"
+        )
+        phrases_path = output_report.with_name(f"{args.wav.stem}_overhead_by_round_phrases.txt")
+        write_by_round_report(
+            reports,
+            output_report,
+            args.wav,
+            wav_start_time,
+            args.tolerance,
+            refine_bundled=not args.no_refine_bundled,
+        )
+        write_by_round_phrases_file(reports, phrases_path)
+        print(f"Phrases file: {phrases_path}", file=sys.stderr)
+        passed = sum(1 for r in reports if r["summary"]["match_rate"] >= args.match_rate_threshold)
+        print("-" * 72)
+        print(f"Rounds passed: {passed}/{len(reports)}")
+        return 0 if passed == len(reports) else 1
+
+    try:
+        wav_duration = get_wav_duration(args.wav)
+    except (subprocess.CalledProcessError, ValueError) as exc:
+        print(f"Error reading wav duration via ffprobe: {exc}", file=sys.stderr)
+        return 1
+
+    last_event = max(
+        (e for e in events if not e.skipped and e.wav_offset_seconds >= 0),
+        key=lambda e: e.wav_offset_seconds,
+        default=None,
+    )
+    if last_event and last_event.wav_offset_seconds > wav_duration + args.tolerance:
+        print(
+            f"Warning: WAV duration ({seconds_to_hms(wav_duration)}) may not cover last "
+            f"scheduled event at wav offset {seconds_to_hms(last_event.wav_offset_seconds)} "
+            f"({last_event.wall_time} {last_event.label or last_event.court})",
+            file=sys.stderr,
+        )
+
+    cache_path = args.transcript_cache or args.wav.with_suffix(args.wav.suffix + ".transcript.json")
+    segments = transcribe_wav(args.wav, args.model, cache_path, args.retranscribe)
+
+    inferred_start: str | None = None
+    if not args.wav_start_time:
+        inferred_start = infer_wav_start_time(
+            events, segments, args.tolerance, args.min_confidence
+        )
+        if inferred_start:
+            print(f"Inferred --wav-start-time: {inferred_start}", file=sys.stderr)
+            wav_start_time = inferred_start
+            events = build_expected_events(
+                games,
+                wav_start_time=wav_start_time,
+                skip_ranges=skip_ranges,
+                skip_before=args.skip_before,
+            )
+        else:
+            print(
+                "Warning: Could not infer wav start time; results use default anchor",
+                file=sys.stderr,
+            )
+
+    results = match_events_to_transcript(
+        events, segments, args.tolerance, args.min_confidence
+    )
+    summary = build_summary(results, courts)
+    orphans = find_orphan_segments(segments, results)
+
+    print_results_table(results)
+    print()
+    print("Summary")
+    print(f"  Match rate: {summary['match_rate']:.1%} ({summary['matched']}/{summary['total_events']})")
+    if summary["max_drift_seconds"] is not None:
+        print(f"  Max drift: {summary['max_drift_seconds']}s")
+        print(f"  Median drift: {summary['median_drift_seconds']}s")
+    print(f"  Skipped: {summary['skipped']}, before wav start: {summary['before_wav_start']}")
+    vw = summary["venue_wide"]
+    print(f"  Venue-wide: {vw['matched']}/{vw['total']} matched")
+    for court_num, stats in summary["per_court"].items():
+        print(f"  Court {court_num} announcements: {stats['matched']}/{stats['total']} matched")
+
+    if summary["missed_events"]:
+        print(f"\nMissed announcements ({len(summary['missed_events'])}):")
+        for item in summary["missed_events"][:20]:
+            who = item["home_team"] or item["label"]
+            print(
+                f"  {item['wall_time']} {item['court']} {item['event_type']}: {who}"
+            )
+        if len(summary["missed_events"]) > 20:
+            print(f"  ... and {len(summary['missed_events']) - 20} more")
+
+    if orphans:
+        print(f"\nOrphan announcements ({len(orphans)}) — heard but not matched to schedule:")
+        for item in orphans[:15]:
+            print(f"  {item['start_hms']}: {item['text'][:80]}")
+        if len(orphans) > 15:
+            print(f"  ... and {len(orphans) - 15} more")
+
+    report = VerificationReport(
+        wav_path=str(args.wav),
+        schedule_date=args.date,
+        wav_start_time=wav_start_time,
+        inferred_wav_start_time=inferred_start,
+        wav_duration_seconds=wav_duration,
+        tolerance_seconds=args.tolerance,
+        skip_ranges=[(seconds_to_hm(a), seconds_to_hm(b)) for a, b in skip_ranges],
+        events=[
+            {
+                "wall_time": r.expected.wall_time,
+                "wav_offset_seconds": r.expected.wav_offset_seconds,
+                "court": r.expected.court,
+                "event_type": r.expected.event_type,
+                "label": r.expected.label,
+                "venue_wide": r.expected.venue_wide,
+                "home_team": r.expected.home_team,
+                "away_team": r.expected.away_team,
+                "round": r.expected.round,
+                "status": r.status,
+                "actual_start": r.actual_start,
+                "drift_seconds": r.drift_seconds,
+                "confidence": round(r.confidence, 3),
+                "matched_text": r.matched_text,
+            }
+            for r in results
+        ],
+        summary=summary,
+        orphan_segments=orphans,
+    )
+
+    output_report = args.output_report or args.wav.with_name(
+        args.wav.stem + "_overhead_verification_report.json"
+    )
+    write_report(report, output_report)
+
+    passed = True
+    if summary["total_events"] == 0:
+        print("\nVerification failed: no events to check.", file=sys.stderr)
+        passed = False
+    elif summary["match_rate"] < args.match_rate_threshold:
+        print(
+            f"\nVerification failed: match rate {summary['match_rate']:.1%} "
+            f"< threshold {args.match_rate_threshold:.1%}",
+            file=sys.stderr,
+        )
+        passed = False
+    elif summary["max_drift_seconds"] is not None and summary["max_drift_seconds"] > args.max_drift:
+        print(
+            f"\nVerification failed: max drift {summary['max_drift_seconds']}s "
+            f"> limit {args.max_drift}s",
+            file=sys.stderr,
+        )
+        passed = False
+
+    if passed:
+        print("\nVerification passed.", file=sys.stderr)
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scripts/verify_overhead_schedule.py
+++ b/src/scripts/verify_overhead_schedule.py
@@ -111,6 +111,40 @@ VENUE_BUNDLE_CUE_TYPES = [
     "countdown",
 ]
 
+SPEECH_ROLE_LABELS: dict[str, str] = {
+    "prior_round_tail": "Countdown/30s from previous round (no blocking gap)",
+    "court_call_court1": "Court 1 matchup call (stream court, not in JSONL)",
+    "court_call_scheduled": "Court 2–4 matchup call (in schedule JSONL)",
+    "court_call_repeat": "Duplicate court call block (Round 1 opening only)",
+    "transition_2min": "Two minutes to next court",
+    "transition_1min": "One minute to your court",
+    "transition_30sec": "30 seconds to your court",
+    "play_start": "Players line up / here we go",
+    "halfway": "Halfway through",
+    "ninety_seconds_warning": "90 seconds remaining",
+    "thirty_seconds_play_end": "30 seconds (end of active play)",
+    "countdown_play_end": "Countdown (play ends)",
+    "thirty_seconds_round_end": "30 seconds (round boundary)",
+    "countdown_round_boundary": "Countdown (round boundary — next round starts)",
+    "no_blocking": "No blocking announcement",
+    "extra_photos": "Team photos / special announcement",
+    "other": "Other speech",
+}
+
+COURT1_RE = re.compile(r"\bcourt\s*(?:one|1)\b", re.I)
+COURT_SCHEDULED_RE = re.compile(r"\bcourt\s*(?:two|three|four|2|3|4)\b", re.I)
+NO_BLOCK_RE = re.compile(r"no\s+block", re.I)
+PHOTOS_RE = re.compile(r"team photos|report to court one for", re.I)
+COUNTDOWN_TEXT_RE = re.compile(
+    r"\b(10|ten)\b.*\b(9|nine)\b|"
+    r"\b7,\s*6,\s*5|"
+    r"\bfive,\s*four|"
+    r"three,\s*two,\s*one|"
+    r"\b2,\s*1\b|"
+    r"seven,\s*six,\s*five",
+    re.I,
+)
+
 _refine_model_cache: dict[str, Any] = {}
 
 
@@ -598,6 +632,162 @@ def collect_slot_speech(
     return items
 
 
+def _offset_near(offset: float, target: int, margin: int = 45) -> bool:
+    return abs(offset - target) <= margin
+
+
+def _looks_like_countdown(text_lower: str) -> bool:
+    return bool(COUNTDOWN_TEXT_RE.search(text_lower))
+
+
+def _is_court_call(text_lower: str) -> bool:
+    return "home team" in text_lower and (
+        COURT1_RE.search(text_lower) or COURT_SCHEDULED_RE.search(text_lower)
+    )
+
+
+def classify_speech_role(item: dict, round_idx: int) -> str:
+    text_lower = item["text"].lower()
+    offset = item["offset_seconds"]
+    cues = item.get("cues", [])
+
+    if NO_BLOCK_RE.search(text_lower):
+        return "no_blocking"
+    if PHOTOS_RE.search(text_lower):
+        return "extra_photos"
+
+    if offset < 0:
+        return "prior_round_tail"
+
+    if _is_court_call(text_lower):
+        if round_idx == 1 and offset >= 55:
+            return "court_call_repeat"
+        if COURT1_RE.search(text_lower):
+            return "court_call_court1"
+        return "court_call_scheduled"
+
+    if "transition_2min" in cues or (
+        _offset_near(offset, 121) and "two minutes" in text_lower
+    ):
+        return "transition_2min"
+    if "transition_1min" in cues or (
+        _offset_near(offset, 173) and "one minute" in text_lower and "remaining" not in text_lower
+    ):
+        return "transition_1min"
+    if "transition_30sec" in cues or (
+        "30 seconds to get" in text_lower
+        or (_offset_near(offset, 202) and "30 seconds" in text_lower and "court" in text_lower)
+    ):
+        return "transition_30sec"
+
+    if "play_start" in cues or (
+        _offset_near(offset, 240)
+        and ("players line up" in text_lower or "here we go" in text_lower)
+    ):
+        return "play_start"
+
+    if "halfway" in cues or (
+        _offset_near(offset, 780) and ("halfway" in text_lower or "way through" in text_lower)
+    ):
+        return "halfway"
+
+    if "ninety_seconds" in cues or (
+        _offset_near(offset, 1235) and ("90 seconds" in text_lower or "ninety seconds" in text_lower)
+    ):
+        return "ninety_seconds_warning"
+
+    if _looks_like_countdown(text_lower):
+        if offset >= 1450 or _offset_near(offset, 1496, margin=90):
+            return "countdown_round_boundary"
+        if offset < 90:
+            return "prior_round_tail"
+        return "countdown_play_end"
+
+    if "30 seconds" in text_lower and "court" not in text_lower:
+        if offset >= 1450 or _offset_near(offset, 1475, margin=75):
+            return "thirty_seconds_round_end"
+        if offset < 90:
+            return "prior_round_tail"
+        if _offset_near(offset, 1294, margin=75) or 1260 <= offset <= 1380:
+            return "thirty_seconds_play_end"
+        if offset >= 1450:
+            return "thirty_seconds_round_end"
+
+    return "other"
+
+
+def annotate_speech_items(speech: list[dict], round_idx: int) -> list[dict]:
+    annotated: list[dict] = []
+    for item in speech:
+        role = classify_speech_role(item, round_idx)
+        annotated.append(
+            {
+                **item,
+                "role": role,
+                "role_label": SPEECH_ROLE_LABELS[role],
+            }
+        )
+    return annotated
+
+
+def summarize_round_structure(speech: list[dict]) -> dict:
+    role_counts: dict[str, int] = {}
+    for item in speech:
+        role = item["role"]
+        role_counts[role] = role_counts.get(role, 0) + 1
+
+    return {
+        "countdown_play_end": role_counts.get("countdown_play_end", 0),
+        "countdown_round_boundary": role_counts.get("countdown_round_boundary", 0),
+        "no_blocking_segments": role_counts.get("no_blocking", 0),
+        "court1_calls": role_counts.get("court_call_court1", 0),
+        "scheduled_court_calls": role_counts.get("court_call_scheduled", 0),
+        "has_photos_or_extra": role_counts.get("extra_photos", 0) > 0,
+        "prior_round_tail_segments": role_counts.get("prior_round_tail", 0),
+        "role_counts": role_counts,
+    }
+
+
+def build_audio_structure_notes(reports: list[dict]) -> dict:
+    all_text = " ".join(item["text"].lower() for report in reports for item in report["speech"])
+    no_blocking_present = bool(NO_BLOCK_RE.search(all_text))
+
+    total_play_end = sum(report["structure"]["countdown_play_end"] for report in reports)
+    total_boundary = sum(report["structure"]["countdown_round_boundary"] for report in reports)
+    photos_rounds = [
+        report["round"]
+        for report in reports
+        if report["structure"]["has_photos_or_extra"]
+    ]
+
+    return {
+        "no_blocking_present": no_blocking_present,
+        "no_blocking_note": (
+            "No 'no blocking' announcements found in this export. Rounds run back-to-back "
+            "with PA cues at the boundary instead of a silent gap."
+            if not no_blocking_present
+            else "No-blocking announcements are present in the export."
+        ),
+        "countdown_pattern": (
+            "Each round typically has two countdowns: ~+22:00 (play ends) and ~+25:00 "
+            "(round boundary / release to next round). Without no-blocking, the next "
+            "round's court calls follow immediately."
+        ),
+        "total_countdown_play_end": total_play_end,
+        "total_countdown_round_boundary": total_boundary,
+        "rounds_with_extra_announcements": photos_rounds,
+        "court1_in_audio_not_in_schedule": True,
+        "verification_scope": (
+            "Matches cover courts 2–4 JSONL matchups and venue-wide PA template cues only. "
+            "The speech timeline includes all detected phrases (Court 1, duplicates, extras)."
+        ),
+        "transcription_note": (
+            "Phrase text is faster-whisper output; timestamps are segment start times. "
+            "Bundled segments are re-transcribed in 8s sub-chunks when --by-round refinement is enabled."
+        ),
+    }
+
+
 def print_slot_transcript(
     speech_items: list[dict],
 ) -> None:
@@ -606,22 +796,31 @@ def print_slot_transcript(
         print("  (no speech detected in this window)")
     else:
         for item in speech_items:
-            cue_str = f"  [{', '.join(item['cues'])}]" if item["cues"] else ""
+            cue_str = f"  [{', '.join(item['cues'])}]" if item.get("cues") else ""
+            role_str = f"  <{item['role']}>" if item.get("role") else ""
             print(
-                f"  {item['wav_timestamp']}  ({item['offset']}){cue_str}  {item['text']}"
+                f"  {item['wav_timestamp']}  ({item['offset']}){role_str}{cue_str}  {item['text']}"
             )
     print()
 
 
-def serialize_refinements(refinements: list[dict], wav_start_seconds: int, slot_anchor: float) -> list[dict]:
+def serialize_refinements(
+    refinements: list[dict],
+    wav_start_seconds: int,
+    slot_anchor: float,
+    round_idx: int,
+) -> list[dict]:
     serialized: list[dict] = []
     for item in refinements:
-        refined_speech = collect_slot_speech(
-            item["refined"],
-            slot_anchor=slot_anchor,
-            wav_start_seconds=wav_start_seconds,
-            pre_seconds=0,
-            post_seconds=26 * 60,
+        refined_speech = annotate_speech_items(
+            collect_slot_speech(
+                item["refined"],
+                slot_anchor=slot_anchor,
+                wav_start_seconds=wav_start_seconds,
+                pre_seconds=0,
+                post_seconds=26 * 60,
+            ),
+            round_idx,
         )
         serialized.append(
             {
@@ -662,13 +861,14 @@ def write_by_round_phrases_file(reports: list[dict], output_path: Path) -> None:
             f"Round {report['round']} ({report['schedule_label']}, wall {report['wall_start']})  "
             f"anchor {seconds_to_hms(report['slot_anchor_wav'])}"
         )
-        lines.append(f"{'WAV':<12} {'OFFSET':<8} {'WALL':<8} {'TEXT'}")
-        lines.append("-" * 90)
+        lines.append(f"{'WAV':<12} {'OFFSET':<8} {'WALL':<8} {'ROLE':<28} {'TEXT'}")
+        lines.append("-" * 110)
         for item in report["speech"]:
-            cue_note = f"  [{', '.join(item['cues'])}]" if item["cues"] else ""
+            cue_note = f"  [{', '.join(item['cues'])}]" if item.get("cues") else ""
+            role = item.get("role", "other")
             lines.append(
                 f"{item['wav_timestamp']:<12} {item['offset']:<8} {item['wall_time']:<8} "
-                f"{item['text']}{cue_note}"
+                f"{role:<28} {item['text']}{cue_note}"
             )
         lines.append("")
     output_path.write_text("\n".join(lines), encoding="utf-8")
@@ -691,6 +891,7 @@ def write_by_round_report(
         "refine_bundled": refine_bundled,
         "rounds_passed": passed,
         "rounds_total": len(reports),
+        "audio_structure": build_audio_structure_notes(reports),
         "rounds": [
             {
                 "round": report["round"],
@@ -702,6 +903,7 @@ def write_by_round_report(
                 "schedule_hint_wav_seconds": report["schedule_hint_wav"],
                 "anchor_drift_seconds": report["anchor_drift"],
                 "bundled_segments_refined": report["bundled_segments_refined"],
+                "structure": report["structure"],
                 "matchups": report["matchups"],
                 "summary": report["summary"],
                 "speech": report["speech"],
@@ -766,12 +968,18 @@ def verify_by_round(
 
         results = match_slot_events(events, slot_segments, tolerance, min_confidence)
         summary = build_summary(results, sorted({g.court_num for g in slot_games}))
-        speech = collect_slot_speech(
-            slot_segments,
-            slot_anchor,
-            global_anchor,
+        speech = annotate_speech_items(
+            collect_slot_speech(
+                slot_segments,
+                slot_anchor,
+                global_anchor,
+            ),
+            round_idx,
         )
-        refined_bundles = serialize_refinements(refinements, global_anchor, slot_anchor)
+        structure = summarize_round_structure(speech)
+        refined_bundles = serialize_refinements(
+            refinements, global_anchor, slot_anchor, round_idx
+        )
 
         report = {
             "round": round_idx,
@@ -782,6 +990,7 @@ def verify_by_round(
             "schedule_hint_wav": hint_wav,
             "anchor_drift": round(slot_anchor - hint_wav, 1),
             "bundled_segments_refined": len(refinements),
+            "structure": structure,
             "matchups": {
                 g.court_num: f"{g.home_team} vs {g.away_team}" for g in slot_games
             },

--- a/src/scripts/verify_overhead_schedule.py
+++ b/src/scripts/verify_overhead_schedule.py
@@ -855,20 +855,42 @@ def serialize_match_results(results: list[MatchResult]) -> list[dict]:
 
 
 def write_by_round_phrases_file(reports: list[dict], output_path: Path) -> None:
-    lines: list[str] = []
+    lines: list[str] = [
+        "Overhead PA speech timeline — all rounds",
+        f"{len(reports)} rounds, {sum(len(r['speech']) for r in reports)} phrases total",
+        "",
+    ]
     for report in reports:
+        structure = report.get("structure", {})
+        matchup_parts = [
+            f"C{court} {matchup}" for court, matchup in sorted(report["matchups"].items())
+        ]
+        lines.append("=" * 110)
         lines.append(
-            f"Round {report['round']} ({report['schedule_label']}, wall {report['wall_start']})  "
-            f"anchor {seconds_to_hms(report['slot_anchor_wav'])}"
+            f"Round {report['round']} ({report['schedule_label']})  "
+            f"wall start {report['wall_start']}"
         )
+        lines.append(
+            f"Anchor: {seconds_to_hms(report['slot_anchor_wav'])}  "
+            f"(drift {report['anchor_drift']:+.0f}s, source {report['anchor_source']})"
+        )
+        lines.append(f"Matchups: {' · '.join(matchup_parts)}")
+        lines.append(
+            "Structure: "
+            f"play_end_countdowns={structure.get('countdown_play_end', 0)}  "
+            f"round_boundary_countdowns={structure.get('countdown_round_boundary', 0)}  "
+            f"prior_round_tail={structure.get('prior_round_tail_segments', 0)}  "
+            f"photos_or_extra={structure.get('has_photos_or_extra', False)}  "
+            f"phrases={len(report['speech'])}"
+        )
+        lines.append("-" * 110)
         lines.append(f"{'WAV':<12} {'OFFSET':<8} {'WALL':<8} {'ROLE':<28} {'TEXT'}")
         lines.append("-" * 110)
         for item in report["speech"]:
-            cue_note = f"  [{', '.join(item['cues'])}]" if item.get("cues") else ""
             role = item.get("role", "other")
             lines.append(
                 f"{item['wav_timestamp']:<12} {item['offset']:<8} {item['wall_time']:<8} "
-                f"{role:<28} {item['text']}{cue_note}"
+                f"{role:<28} {item['text']}"
             )
         lines.append("")
     output_path.write_text("\n".join(lines), encoding="utf-8")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Shared pytest configuration for video-editor tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "src" / "scripts"
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))

--- a/tests/fixtures/minimal_by_round_report.json
+++ b/tests/fixtures/minimal_by_round_report.json
@@ -1,0 +1,59 @@
+{
+  "wav_start_time": "09:00",
+  "rounds": [
+    {
+      "round": 1,
+      "schedule_label": "Round 1",
+      "speech": [
+        {
+          "wav_seconds": 1000.0,
+          "wav_timestamp": "00:16:40",
+          "offset_seconds": 240,
+          "text": "Players line up, here we go",
+          "role": "play_start"
+        },
+        {
+          "wav_seconds": 1540.0,
+          "wav_timestamp": "00:25:40",
+          "offset_seconds": 780,
+          "text": "Halfway through the round",
+          "role": "halfway"
+        },
+        {
+          "wav_seconds": 1996.0,
+          "wav_timestamp": "00:33:16",
+          "offset_seconds": 1496,
+          "text": "Ten, nine, eight, seven, six, five, four, three, two, one",
+          "role": "countdown_play_end"
+        },
+        {
+          "wav_seconds": 2100.0,
+          "wav_timestamp": "00:35:00",
+          "offset_seconds": 1600,
+          "text": "Ten, nine, eight, seven, six, five, four, three, two, one",
+          "role": "countdown_round_boundary"
+        }
+      ]
+    },
+    {
+      "round": 2,
+      "schedule_label": "Round 2",
+      "speech": [
+        {
+          "wav_seconds": 2500.0,
+          "wav_timestamp": "00:41:40",
+          "offset_seconds": 240,
+          "text": "Players line up",
+          "role": "play_start"
+        },
+        {
+          "wav_seconds": 3496.0,
+          "wav_timestamp": "00:58:16",
+          "offset_seconds": 1496,
+          "text": "Three, two, one",
+          "role": "countdown_play_end"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/schedule/2026-06-20_court2.jsonl
+++ b/tests/fixtures/schedule/2026-06-20_court2.jsonl
@@ -1,0 +1,2 @@
+{"type":"round_robin","round":"Round 1","home_team":"Alpha Squad","away_team":"Beta Brawlers","start_time":"09:00","minutes":25,"court":"Court 2"}
+{"type":"round_robin","round":"Round 2","home_team":"Gamma Grapplers","away_team":"Delta Dunks","start_time":"09:25","minutes":25,"court":"Court 2"}

--- a/tests/test_inject_no_blocking.py
+++ b/tests/test_inject_no_blocking.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from inject_no_blocking import (
+    find_play_end_countdown,
+    in_silence_search_window,
+    list_no_blocking_silence_candidates,
+    looks_like_countdown,
+    speech_before_insert,
+)
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def load_round(round_num: int) -> dict:
+    report = json.loads((FIXTURES / "minimal_by_round_report.json").read_text(encoding="utf-8"))
+    return next(item for item in report["rounds"] if item["round"] == round_num)
+
+
+class TestFindPlayEndCountdown:
+    def test_picks_last_play_end_before_boundary(self):
+        countdown = find_play_end_countdown(load_round(1))
+        assert countdown is not None
+        assert countdown["role"] == "countdown_play_end"
+        assert countdown["wav_seconds"] == 1996.0
+
+    def test_returns_only_play_end_when_no_boundary(self):
+        countdown = find_play_end_countdown(load_round(2))
+        assert countdown is not None
+        assert countdown["wav_seconds"] == 3496.0
+
+
+class TestLooksLikeCountdown:
+    def test_matches_common_patterns(self):
+        assert looks_like_countdown("Ten, nine, eight, seven")
+        assert looks_like_countdown("Three, two, one")
+        assert not looks_like_countdown("Players line up")
+
+
+class TestSilenceSearchWindow:
+    def test_accepts_long_silence_after_countdown(self):
+        silence = {"start": 2010.0, "end": 2030.0, "duration": 20.0}
+        assert in_silence_search_window(
+            silence,
+            countdown_start=1996.0,
+            min_after_countdown=3.0,
+            max_offset=120.0,
+            min_no_blocking_silence=15.0,
+        )
+
+    def test_rejects_silence_too_early_and_short(self):
+        silence = {"start": 1997.0, "end": 1999.0, "duration": 2.0}
+        assert not in_silence_search_window(
+            silence,
+            countdown_start=1996.0,
+            min_after_countdown=3.0,
+            max_offset=120.0,
+            min_no_blocking_silence=15.0,
+        )
+
+
+class TestListNoBlockingSilenceCandidates:
+    def test_orders_earliest_first(self):
+        silences = [
+            {"start": 2050.0, "end": 2070.0, "duration": 20.0},
+            {"start": 2010.0, "end": 2030.0, "duration": 20.0},
+        ]
+        candidates = list_no_blocking_silence_candidates(
+            silences,
+            countdown_start=1996.0,
+            min_after_countdown=3.0,
+            min_no_blocking_silence=15.0,
+        )
+        assert [item["start"] for item in candidates] == [2010.0, 2050.0]
+
+
+class TestSpeechBeforeInsert:
+    def test_detects_blocking_speech(self):
+        round_data = load_round(1)
+        overlap = speech_before_insert(round_data, countdown_start=1996.0, insert_at=2110.0)
+        assert overlap is not None
+        assert overlap["role"] == "countdown_round_boundary"
+
+    def test_ignores_play_end_countdown_itself(self):
+        round_data = {
+            "speech": [
+                {
+                    "wav_seconds": 1996.0,
+                    "wav_timestamp": "00:33:16",
+                    "role": "countdown_play_end",
+                    "text": "three two one",
+                }
+            ]
+        }
+        assert speech_before_insert(round_data, countdown_start=1996.0, insert_at=2010.0) is None

--- a/tests/test_inject_start_buzzer.py
+++ b/tests/test_inject_start_buzzer.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from inject_start_buzzer import (
+    estimate_phrase_end_from_report,
+    find_play_start_cues,
+    play_start_phrase_end_from_transcript,
+    segment_play_start_end,
+    speech_overlap_before_insert,
+    validate_insert_point,
+)
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def load_round(round_num: int) -> dict:
+    report = json.loads((FIXTURES / "minimal_by_round_report.json").read_text(encoding="utf-8"))
+    return next(item for item in report["rounds"] if item["round"] == round_num)
+
+
+class TestSegmentPlayStartEnd:
+    def test_caps_long_bundled_segment(self):
+        segment = {
+            "start": 1000.0,
+            "end": 1010.0,
+            "text": "Players line up, here we go, court two",
+        }
+        assert segment_play_start_end(segment) == 1004.5
+
+    def test_caps_here_we_go_only(self):
+        segment = {"start": 1000.0, "end": 1005.0, "text": "Here we go"}
+        assert segment_play_start_end(segment) == 1002.5
+
+
+class TestPhraseEndEstimation:
+    def test_single_play_start_cue(self):
+        cues = [{"wav_seconds": 1000.0}]
+        assert estimate_phrase_end_from_report(cues) == 1004.0
+
+    def test_split_phrase_uses_last_cue(self):
+        cues = [{"wav_seconds": 1000.0}, {"wav_seconds": 1002.5}]
+        assert estimate_phrase_end_from_report(cues) == 1004.5
+
+
+class TestPlayStartPhraseEndFromTranscript:
+    def test_finds_phrase_end_in_window(self):
+        transcript = {
+            "segments": [
+                {"start": 999.5, "end": 1004.0, "text": "Players line up, here we go"},
+                {"start": 1540.0, "end": 1543.0, "text": "Halfway through"},
+            ]
+        }
+        end = play_start_phrase_end_from_transcript(transcript, first_play_start=1000.0)
+        assert end == 1004.0
+
+
+class TestFindPlayStartCues:
+    def test_filters_play_start_roles(self):
+        cues = find_play_start_cues(load_round(1))
+        assert len(cues) == 1
+        assert cues[0]["role"] == "play_start"
+
+
+class TestSpeechOverlapBeforeInsert:
+    def test_finds_halfway_between_phrase_and_insert(self):
+        overlap = speech_overlap_before_insert(
+            load_round(1),
+            first_play_start=1000.0,
+            insert_at=1550.0,
+        )
+        assert overlap is not None
+        assert overlap["role"] == "halfway"
+
+
+class TestValidateInsertPoint:
+    @patch("inject_start_buzzer.max_volume_db", return_value=-40.0)
+    def test_high_confidence_when_clear(self, _mock_volume):
+        result = validate_insert_point(
+            wav_path=Path("/tmp/unused.wav"),
+            round_data=load_round(1),
+            first_play_start=1000.0,
+            insert_at=1004.0,
+            phrase_end=1004.0,
+        )
+        assert result["insert_confidence"] == "high"
+        assert result["insert_phrase_clear"]
+        assert result["insert_speech_overlap"] is None
+
+    @patch("inject_start_buzzer.max_volume_db", return_value=-40.0)
+    def test_low_confidence_when_before_phrase_end(self, _mock_volume):
+        result = validate_insert_point(
+            wav_path=Path("/tmp/unused.wav"),
+            round_data=load_round(1),
+            first_play_start=1000.0,
+            insert_at=1002.0,
+            phrase_end=1004.0,
+        )
+        assert result["insert_confidence"] == "low"
+        assert not result["insert_phrase_clear"]

--- a/tests/test_overhead_inject_common.py
+++ b/tests/test_overhead_inject_common.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from overhead_inject_common import build_ffmpeg_command, seconds_to_hms
+
+
+class TestSecondsToHms:
+    def test_formats_hours(self):
+        assert seconds_to_hms(3661) == "01:01:01"
+
+
+class TestBuildFfmpegCommand:
+    def test_single_insert_includes_filter_complex(self, tmp_path: Path):
+        wav = tmp_path / "source.wav"
+        clip = tmp_path / "clip.wav"
+        out = tmp_path / "out.wav"
+        wav.touch()
+        clip.touch()
+
+        cmd = build_ffmpeg_command(wav, clip, out, [120.5], sample_rate=48000, channels=2)
+        assert cmd[0] == "ffmpeg"
+        assert "-filter_complex" in cmd
+        filter_complex = cmd[cmd.index("-filter_complex") + 1]
+        assert "asplit=1" in filter_complex
+        assert "adelay=120500|120500" in filter_complex
+        assert "amix=inputs=2" in filter_complex
+
+    def test_multiple_inserts_split_clip(self, tmp_path: Path):
+        wav = tmp_path / "source.wav"
+        clip = tmp_path / "clip.wav"
+        out = tmp_path / "out.wav"
+        wav.touch()
+        clip.touch()
+
+        cmd = build_ffmpeg_command(
+            wav, clip, out, [10.0, 20.0, 30.0], sample_rate=44100, channels=1
+        )
+        filter_complex = cmd[cmd.index("-filter_complex") + 1]
+        assert "asplit=3" in filter_complex
+        assert "channel_layouts=mono" in filter_complex
+        assert "amix=inputs=4" in filter_complex
+
+    def test_rejects_empty_insert_list(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="No insertion timestamps"):
+            build_ffmpeg_command(
+                tmp_path / "a.wav",
+                tmp_path / "b.wav",
+                tmp_path / "c.wav",
+                [],
+                sample_rate=48000,
+                channels=2,
+            )

--- a/tests/test_verify_overhead_schedule.py
+++ b/tests/test_verify_overhead_schedule.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from verify_overhead_schedule import (
+    ExpectedEvent,
+    Game,
+    TranscriptSegment,
+    build_expected_events,
+    classify_speech_role,
+    in_skip_range,
+    load_games,
+    match_events_to_transcript,
+    normalize_team,
+    parse_skip_ranges,
+    score_segment,
+    seconds_to_hms,
+    time_to_seconds,
+)
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+SCHEDULE_DIR = FIXTURES / "schedule"
+
+
+class TestTimeHelpers:
+    def test_time_to_seconds_hm(self):
+        assert time_to_seconds("09:00") == 9 * 3600
+        assert time_to_seconds("09:25") == 9 * 3600 + 25 * 60
+
+    def test_time_to_seconds_hms(self):
+        assert time_to_seconds("09:00:30") == 9 * 3600 + 30
+
+    def test_time_to_seconds_invalid(self):
+        with pytest.raises(ValueError, match="Invalid time"):
+            time_to_seconds("9am")
+
+    def test_seconds_to_hms(self):
+        assert seconds_to_hms(3661) == "01:01:01"
+        assert seconds_to_hms(-5) == "00:00:00"
+
+
+class TestNormalizeTeam:
+    def test_strips_the_and_punctuation(self):
+        assert normalize_team("The Alpha-Squad!") == "alphasquad"
+
+
+class TestSkipRanges:
+    def test_parse_skip_ranges(self):
+        assert parse_skip_ranges(["12:05-13:30"]) == [
+            (12 * 3600 + 5 * 60, 13 * 3600 + 30 * 60)
+        ]
+
+    def test_parse_skip_ranges_invalid(self):
+        with pytest.raises(ValueError, match="Invalid skip range"):
+            parse_skip_ranges(["noon"])
+
+    def test_in_skip_range(self):
+        ranges = parse_skip_ranges(["12:00-13:00"])
+        assert in_skip_range(12 * 3600 + 30 * 60, ranges)
+        assert not in_skip_range(11 * 3600, ranges)
+
+
+class TestLoadGames:
+    def test_load_games_from_fixture(self):
+        games = load_games(SCHEDULE_DIR, "2026-06-20", [2])
+        assert len(games) == 2
+        assert games[0].home_team == "Alpha Squad"
+        assert games[0].court_num == 2
+        assert games[1].start_time == "09:25"
+
+    def test_load_games_missing_file(self):
+        with pytest.raises(FileNotFoundError):
+            load_games(SCHEDULE_DIR, "2026-06-20", [99])
+
+
+class TestBuildExpectedEvents:
+    @pytest.fixture
+    def games(self) -> list[Game]:
+        return load_games(SCHEDULE_DIR, "2026-06-20", [2])
+
+    def test_builds_venue_wide_and_court_events(self, games: list[Game]):
+        events = build_expected_events(games, "09:00", skip_ranges=[])
+        venue = [e for e in events if e.venue_wide]
+        court = [e for e in events if not e.venue_wide]
+        assert len(venue) > 0
+        assert len(court) > 0
+        assert all(e.wav_offset_seconds >= 0 for e in events if not e.skipped)
+
+    def test_skip_before_marks_early_events_skipped(self, games: list[Game]):
+        events = build_expected_events(games, "09:00", skip_ranges=[], skip_before="09:10")
+        skipped = [e for e in events if e.skipped]
+        active = [e for e in events if not e.skipped]
+        assert skipped
+        assert active
+        assert all(e.wall_seconds >= time_to_seconds("09:10") for e in active)
+
+
+class TestClassifySpeechRole:
+    def test_play_start(self):
+        role = classify_speech_role(
+            {"text": "Players line up, here we go", "offset_seconds": 240, "cues": ["play_start"]},
+            round_idx=1,
+        )
+        assert role == "play_start"
+
+    def test_no_blocking(self):
+        role = classify_speech_role(
+            {"text": "Three minutes, no blocking", "offset_seconds": 900, "cues": []},
+            round_idx=1,
+        )
+        assert role == "no_blocking"
+
+    def test_countdown_play_end_vs_boundary(self):
+        play_end = classify_speech_role(
+            {"text": "Ten, nine, eight", "offset_seconds": 1350, "cues": ["countdown"]},
+            round_idx=1,
+        )
+        boundary = classify_speech_role(
+            {"text": "Ten, nine, eight", "offset_seconds": 1600, "cues": ["countdown"]},
+            round_idx=1,
+        )
+        assert play_end == "countdown_play_end"
+        assert boundary == "countdown_round_boundary"
+
+    def test_prior_round_tail_negative_offset(self):
+        role = classify_speech_role(
+            {"text": "Three, two, one", "offset_seconds": -30, "cues": []},
+            round_idx=2,
+        )
+        assert role == "prior_round_tail"
+
+
+class TestMatching:
+    def test_score_segment_court_call(self):
+        event = ExpectedEvent(
+            wall_time="09:00",
+            wall_seconds=time_to_seconds("09:00"),
+            wav_offset_seconds=0,
+            event_type="court_announcement",
+            court_num=2,
+            court="Court 2",
+            home_team="Alpha Squad",
+            away_team="Beta Brawlers",
+            round="Round 1",
+        )
+        segment = TranscriptSegment(
+            start=5.0,
+            end=12.0,
+            text="Court two, Alpha Squad versus Beta Brawlers, home team Alpha Squad",
+        )
+        assert score_segment(event, segment) >= 0.55
+
+    def test_match_events_to_transcript_finds_play_start(self):
+        slot_start = time_to_seconds("09:00")
+        anchor = slot_start
+        events = [
+            ExpectedEvent(
+                wall_time="09:04",
+                wall_seconds=slot_start + 240,
+                wav_offset_seconds=240.0,
+                event_type="play_start",
+                court_num=0,
+                court="ALL",
+                home_team="",
+                away_team="",
+                round="Round 1",
+                venue_wide=True,
+                label="Players line up / here we go",
+            )
+        ]
+        segments = [
+            TranscriptSegment(start=238.0, end=244.0, text="Players line up, here we go")
+        ]
+        results = match_events_to_transcript(events, segments, tolerance=90, min_confidence=0.55)
+        assert len(results) == 1
+        assert results[0].matched
+        assert results[0].matched_text == segments[0].text


### PR DESCRIPTION
## Summary
- Add overhead WAV verification against Throw Down schedule JSONL with by-round speech timeline reports and PA role annotation.
- Add no-blocking clip injection after play-end buzzer using silencedetect to locate the post-countdown silence window.
- Add Start buzzer injection at play start (after no-blocking), with shared ffmpeg/report utilities in `overhead_inject_common.py`.
- Document verification and injection workflows in `TOURNAMENT_RUNBOOK.md`.

## Test plan
- [ ] `./src/bash/verify_overhead_schedule.sh --wav ... --by-round` passes 10/10 rounds on June 2026 schedule
- [ ] `./src/bash/inject_no_blocking.sh --dry-run` shows 10 high-confidence insert points
- [ ] `./src/bash/inject_start_buzzer.sh --dry-run` shows 10 play-start buzzer insert points
- [ ] Output WAV duration unchanged after both injection steps
- [ ] Re-run `--by-round` verification on final output WAV


Made with [Cursor](https://cursor.com)