### PR TITLE
Add Throw Down team SD processing and bracket placeholder slots

### DIFF
--- a/TOURNAMENT_RUNBOOK.md
+++ b/TOURNAMENT_RUNBOOK.md
@@ -48,7 +48,119 @@ Drop the Excel file at `schedule/master_schedule.xlsx`, then:
 
 This parses Throw Down **team sheets** (`PLAYING : Court N (HOME) vs. ...`) and skips Court 1 (stream).
 
-**Current schedule coverage:** Saturday round robin only (30 games, courts 2–4). Re-run the converter when bracket and Sunday matchups are added to the spreadsheet.
+**Current schedule coverage:** Saturday round robin plus **bracket placeholder slots** (TBD teams) for courts 2–4 from 13:50 onward. The same court SD workflow splits both. Fill in team names after seeding with `fill_bracket_teams.py`, or re-run the converter once Overview Schedule bracket rows are filled in.
+
+### Bracket placeholders (TBD → real teams)
+
+Court JSONL includes one bracket slot per court per bracket time with `TBD` teams until matchups are known. Split filenames include the start time to keep them unique:
+
+```
+Bracket Quarters: Court 2: 14:40: TBD vs TBD.mp4
+```
+
+After seeding:
+
+```bash
+.venv/bin/python src/scripts/fill_bracket_teams.py \
+  --jsonl src/output/June2026Tournament/schedule/generated/2026-06-20_court2.jsonl \
+  --updates src/output/June2026Tournament/schedule/bracket_teams.json \
+  --split-dir src/output/June2026Tournament/2026-06-20/court2/split_videos \
+  --rename
+```
+
+See `schedule/bracket_teams.example.json` for the updates file format.
+
+## Team GoPro SD cards (optional)
+
+Some teams record their own sideline footage (e.g. Sister Sister). Team sheets in the same Excel workbook list every **PLAYING** slot for that team — including stream-court and away games that the court converter skips.
+
+### Folder layout
+
+```
+src/output/June2026Tournament/
+├── teams/
+│   ├── sister_sister/
+│   │   ├── 2026-06-20/          # raw GX*.MP4 + merged_videos/ + split_videos/
+│   │   └── 2026-06-21/
+│   └── fresh_prince/
+│       └── ...
+├── schedule/
+│   ├── generated/               # court JSONL ({date}_court{N}.jsonl)
+│   └── generated_teams/         # team JSONL ({date}_{team_slug}.jsonl)
+```
+
+Label each team SD card (e.g. `Team-Sister-Sister-Sat`). Import Saturday and Sunday clips into the matching day folder.
+
+### One-time team setup
+
+```bash
+./src/bash/setup_team_folders.sh src/output/June2026Tournament
+# Or only specific teams:
+./src/bash/setup_team_folders.sh src/output/June2026Tournament --teams "Sister Sister,Fresh Prince"
+```
+
+### Team schedule → JSONL
+
+Uses the same `master_schedule.xlsx` as the court converter:
+
+```bash
+.venv/bin/python src/scripts/excel_team_schedule_to_jsonl.py \
+  src/output/June2026Tournament/schedule/master_schedule.xlsx \
+  --output-dir src/output/June2026Tournament/schedule/generated_teams \
+  --date 2026-06-20 --minutes 25
+
+# List team sheet names and folder slugs:
+.venv/bin/python src/scripts/excel_team_schedule_to_jsonl.py \
+  src/output/June2026Tournament/schedule/master_schedule.xlsx --list-teams
+
+# Single team only:
+.venv/bin/python src/scripts/excel_team_schedule_to_jsonl.py \
+  src/output/June2026Tournament/schedule/master_schedule.xlsx \
+  --teams "Sister Sister" \
+  --output-dir src/output/June2026Tournament/schedule/generated_teams \
+  --date 2026-06-20
+```
+
+Re-run with `--date 2026-06-21` when Sunday matchups are in the workbook.
+
+### After each day (team footage)
+
+**1. Import team SD card**
+
+```bash
+./src/bash/import_team_sd.sh \
+  --dest src/output/June2026Tournament/teams/sister_sister/2026-06-20 \
+  --card Team-Sister-Sister-Sat
+```
+
+**2. Merge + split**
+
+```bash
+./src/bash/process_team_day.sh \
+  src/output/June2026Tournament \
+  --date 2026-06-20 --teams sister_sister --dry-run
+
+./src/bash/process_team_day.sh \
+  src/output/June2026Tournament \
+  --date 2026-06-20 --teams sister_sister
+```
+
+Process all teams with imported footage (omit `--teams`):
+
+```bash
+./src/bash/process_team_day.sh src/output/June2026Tournament --date 2026-06-20
+```
+
+Team matchup files land in `teams/{slug}/{date}/split_videos/` with names like:
+
+```
+Round Robin Round 2: Court 2: Sister Sister vs Static Shock.mp4
+Bracket Quarters: Court 3: Sister Sister vs Family Matters.mp4
+```
+
+Playoff games are detected automatically from start times at or after bracket play (13:50 Saturday). The first half of the filename uses the inferred bracket round (`Round 1`, `Quarters`, `Semis`, `Finals`, `Championship`) instead of `Round Robin Round N`. Re-run the team schedule converter after bracket matchups are added to the Excel sheets.
+
+`collect_deliverables.sh` picks up team split videos under `deliverables/teams/{slug}/{date}/`.
 
 ## Overhead audio verification
 
@@ -214,6 +326,11 @@ Options:
 | `validate_tournament_setup.sh` | Test pipeline on sample Week2 footage |
 | `verify_overhead_schedule.sh` | Verify overhead .wav vs schedule JSONL |
 | `excel_schedule_to_jsonl.py` | Excel → per-court `games.jsonl` |
+| `excel_team_schedule_to_jsonl.py` | Excel → per-team `games.jsonl` |
+| `setup_team_folders.sh` | Create `teams/{slug}/{date}/` tree |
+| `import_team_sd.sh` | Team SD card → team day folder |
+| `process_team_day.sh` | Merge + split all team footage for one day |
+| `fill_bracket_teams.py` | Fill bracket team names + rename TBD split videos |
 
 Lower-level scripts (called automatically): `combine_gopro_videos.sh`, `split_multi_source_videos.sh`.
 

--- a/src/bash/collect_deliverables.sh
+++ b/src/bash/collect_deliverables.sh
@@ -79,7 +79,11 @@ count=0
 while IFS= read -r -d '' video; do
   filename="$(basename "$video")"
   rel="${video#$tournament_root/}"
-  day_court="$(echo "$rel" | cut -d/ -f1-2)"
+  if [[ "$rel" == teams/* ]]; then
+    day_court="$(echo "$rel" | cut -d/ -f1-3)"
+  else
+    day_court="$(echo "$rel" | cut -d/ -f1-2)"
+  fi
   if [ -z "$day_court" ] || [ "$day_court" = "$rel" ]; then
     day_court="unknown"
   fi

--- a/src/bash/import_team_sd.sh
+++ b/src/bash/import_team_sd.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+
+# Import a team GoPro SD card into a tournament team/day folder.
+# Usage: import_team_sd.sh --dest <team_day_directory> [--source <volume_path>] [--dry-run]
+#
+# Example:
+#   ./import_team_sd.sh \
+#     --dest src/output/June2026Tournament/teams/sister_sister/2026-06-20 \
+#     --card Team-Sister-Sister-Sat
+
+set -e
+
+GOPRO_DCIM="DCIM/100GOPRO"
+GOPRO_PATTERNS=("GX??????.MP4" "GP??????.MP4" "GOPR????.MP4")
+
+dest_dir=""
+source_volume=""
+dry_run=false
+card_label=""
+
+show_usage() {
+  cat << EOF
+Usage: $0 --dest <team_day_directory> [options]
+
+Required:
+  --dest DIR       Team day folder (e.g. .../teams/sister_sister/2026-06-20)
+
+Options:
+  --source PATH    SD card mount path (default: auto-detect GoPro volume)
+  --card LABEL     Card label for logging (e.g. Team-Sister-Sister-Sat)
+  --dry-run        Show what would be copied without copying
+  -h, --help       Show this help
+
+Examples:
+  $0 --dest src/output/June2026Tournament/teams/sister_sister/2026-06-20 --card Team-Sister-Sister-Sat
+  $0 --dest src/output/June2026Tournament/teams/fresh_prince/2026-06-21 --source /Volumes/Untitled --dry-run
+EOF
+}
+
+detect_gopro_volumes() {
+  local volumes=()
+  for volume in /Volumes/*; do
+    [ -d "$volume" ] || continue
+    volume_name="$(basename "$volume")"
+    if [[ "$volume_name" == "Macintosh HD"* ]] || [[ "$volume_name" == "System"* ]]; then
+      continue
+    fi
+    if [ -d "$volume/$GOPRO_DCIM" ]; then
+      local count=0
+      for pattern in "${GOPRO_PATTERNS[@]}"; do
+        count=$((count + $(find "$volume/$GOPRO_DCIM" -maxdepth 1 -name "$pattern" 2>/dev/null | wc -l | tr -d ' ')))
+      done
+      if [ "$count" -gt 0 ]; then
+        volumes+=("$volume")
+        echo "Found GoPro card: $volume_name ($count files)" >&2
+      fi
+    fi
+  done
+  printf '%s\n' "${volumes[@]}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dest)
+      dest_dir="$2"
+      shift 2
+      ;;
+    --source)
+      source_volume="$2"
+      shift 2
+      ;;
+    --card)
+      card_label="$2"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    -h|--help)
+      show_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      show_usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$dest_dir" ]; then
+  show_usage
+  exit 1
+fi
+
+if [[ "$dest_dir" =~ \  ]]; then
+  echo "Error: Destination path contains spaces."
+  exit 1
+fi
+
+mkdir -p "$dest_dir/merged_videos" "$dest_dir/split_videos"
+
+if [ -z "$source_volume" ]; then
+  volumes=()
+  while IFS= read -r vol; do
+    [ -n "$vol" ] && volumes+=("$vol")
+  done < <(detect_gopro_volumes)
+  if [ ${#volumes[@]} -eq 0 ]; then
+    echo "Error: No GoPro SD cards detected. Insert card or pass --source."
+    exit 1
+  elif [ ${#volumes[@]} -eq 1 ]; then
+    source_volume="${volumes[0]}"
+  else
+    echo "Multiple GoPro SD cards detected:"
+    for i in "${!volumes[@]}"; do
+      echo "  $((i + 1))) ${volumes[$i]}"
+    done
+    while true; do
+      echo -n "Select card number (1-${#volumes[@]}): "
+      read -r selection
+      if [[ "$selection" =~ ^[0-9]+$ ]] && [ "$selection" -ge 1 ] && [ "$selection" -le ${#volumes[@]} ]; then
+        source_volume="${volumes[$((selection - 1))]}"
+        break
+      fi
+      echo "Invalid selection. Enter a number between 1 and ${#volumes[@]}."
+    done
+  fi
+fi
+
+gopro_dir="$source_volume/$GOPRO_DCIM"
+if [ ! -d "$gopro_dir" ]; then
+  echo "Error: GoPro directory not found: $gopro_dir"
+  exit 1
+fi
+
+label="${card_label:-$(basename "$source_volume")}"
+echo "=== Team SD Import ==="
+echo "Card:        $label"
+echo "Source:      $gopro_dir"
+echo "Destination: $dest_dir"
+echo "Dry run:     $dry_run"
+echo ""
+
+copied=0
+skipped=0
+would_copy=0
+
+for pattern in "${GOPRO_PATTERNS[@]}"; do
+  while IFS= read -r -d '' file; do
+    filename="$(basename "$file")"
+    dest_file="$dest_dir/$filename"
+    if [ -f "$dest_file" ]; then
+      echo "Skip (exists): $filename"
+      skipped=$((skipped + 1))
+      continue
+    fi
+    if [ "$dry_run" = true ]; then
+      echo "Would copy: $filename"
+      would_copy=$((would_copy + 1))
+    else
+      cp -p "$file" "$dest_file"
+      echo "Copied: $filename"
+      copied=$((copied + 1))
+    fi
+  done < <(find "$gopro_dir" -maxdepth 1 -name "$pattern" -print0 2>/dev/null)
+done
+
+echo ""
+if [ "$dry_run" = true ]; then
+  echo "Dry run complete: $would_copy file(s) would be copied, $skipped already present."
+else
+  echo "Import complete: $copied new file(s), $skipped already present."
+fi

--- a/src/bash/process_team_day.sh
+++ b/src/bash/process_team_day.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+
+# Process team GoPro footage for one tournament day: merge clips + split into matchups.
+# Usage: process_team_day.sh <tournament_root> --date YYYY-MM-DD [options]
+#
+# Example:
+#   ./process_team_day.sh src/output/June2026Tournament \
+#     --date 2026-06-20 --teams sister_sister,fresh_prince
+
+set -e
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+combine_script="$script_dir/combine_gopro_videos.sh"
+split_script="$script_dir/split_multi_source_videos.sh"
+
+tournament_root=""
+day=""
+schedule_dir=""
+teams=""
+tournament_name=""
+dry_run=false
+
+show_usage() {
+  cat << EOF
+Usage: $0 <tournament_root> --date YYYY-MM-DD [options]
+
+  <tournament_root>   Tournament folder containing teams/ and schedule/
+
+Options:
+  --date DATE          Tournament day (required), e.g. 2026-06-20
+  --schedule-dir DIR   Directory with {date}_{team_slug}.jsonl files
+  --teams LIST         Comma-separated team slugs (default: all teams with footage)
+  --tournament NAME    Tournament name for split output (default: parent folder name)
+  --dry-run            Preview split only; skip merge and ffmpeg writes
+  -h, --help           Show this help
+
+Examples:
+  $0 src/output/June2026Tournament --date 2026-06-20 --teams sister_sister
+  $0 src/output/June2026Tournament --date 2026-06-21 --dry-run
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --date)
+      day="$2"
+      shift 2
+      ;;
+    --schedule-dir)
+      schedule_dir="$2"
+      shift 2
+      ;;
+    --teams)
+      teams="$2"
+      shift 2
+      ;;
+    --tournament)
+      tournament_name="$2"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    -h|--help)
+      show_usage
+      exit 0
+      ;;
+    -*)
+      echo "Unknown option: $1"
+      show_usage
+      exit 1
+      ;;
+    *)
+      if [ -z "$tournament_root" ]; then
+        tournament_root="$1"
+      else
+        echo "Unexpected argument: $1"
+        show_usage
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$tournament_root" ] || [ -z "$day" ]; then
+  show_usage
+  exit 1
+fi
+
+if [[ "$tournament_root" =~ \  ]]; then
+  echo "Error: Tournament root path contains spaces."
+  exit 1
+fi
+
+if [ ! -d "$tournament_root" ]; then
+  echo "Error: Tournament root not found: $tournament_root"
+  exit 1
+fi
+
+tournament_root="$(cd "$tournament_root" && pwd)"
+
+if [ -z "$tournament_name" ]; then
+  tournament_name="$(basename "$tournament_root")"
+fi
+
+teams_dir="$tournament_root/teams"
+if [ ! -d "$teams_dir" ]; then
+  echo "Error: No teams/ directory under $tournament_root"
+  echo "Run: $script_dir/setup_team_folders.sh $tournament_root"
+  exit 1
+fi
+
+if [ -z "$schedule_dir" ]; then
+  if [ -d "$tournament_root/schedule/generated_teams" ]; then
+    schedule_dir="$tournament_root/schedule/generated_teams"
+  fi
+fi
+
+if [ -n "$schedule_dir" ] && [ ! -d "$schedule_dir" ]; then
+  echo "Error: Schedule directory not found: $schedule_dir"
+  exit 1
+fi
+
+team_list=()
+if [ -n "$teams" ]; then
+  IFS=',' read -ra team_list <<< "$teams"
+else
+  while IFS= read -r team_slug; do
+    [ -n "$team_slug" ] || continue
+    team_day_dir="$teams_dir/$team_slug/$day"
+    if [ -d "$team_day_dir" ]; then
+      team_list+=("$team_slug")
+    fi
+  done < <(find "$teams_dir" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort)
+fi
+
+if [ ${#team_list[@]} -eq 0 ]; then
+  echo "Error: No team folders found for $day under $teams_dir"
+  exit 1
+fi
+
+echo "=== Team Day Processing ==="
+echo "Day:           $day"
+echo "Tournament:    $tournament_name"
+echo "Teams:         ${team_list[*]}"
+echo "Schedule dir:  ${schedule_dir:-none}"
+echo "Dry run:       $dry_run"
+echo ""
+
+for team_slug in "${team_list[@]}"; do
+  team_slug="$(echo "$team_slug" | tr -d ' ')"
+  team_day_dir="$teams_dir/$team_slug/$day"
+  team_label="$team_slug"
+
+  echo "--- Processing team: $team_label ($day) ---"
+
+  if [ ! -d "$team_day_dir" ]; then
+    echo "Warning: $team_day_dir not found, skipping."
+    continue
+  fi
+
+  gx_count=$(find "$team_day_dir" -maxdepth 1 -name 'GX??????.MP4' 2>/dev/null | wc -l | tr -d ' ')
+  gp_count=$(find "$team_day_dir" -maxdepth 1 -name 'GP??????.MP4' 2>/dev/null | wc -l | tr -d ' ')
+  gopr_count=$(find "$team_day_dir" -maxdepth 1 -name 'GOPR????.MP4' 2>/dev/null | wc -l | tr -d ' ')
+  gopro_count=$((gx_count + gp_count + gopr_count))
+
+  if [ "$gopro_count" -eq 0 ] && [ "$dry_run" = false ]; then
+    echo "No GoPro files in $team_day_dir, skipping."
+    continue
+  fi
+
+  echo "Found $gopro_count GoPro files (GX: $gx_count, GP: $gp_count, GOPR: $gopr_count)"
+
+  if [ "$dry_run" = false ]; then
+    echo "Merging clips..."
+    if ! "$combine_script" "$team_day_dir"; then
+      echo "Error: merge failed for $team_label"
+      continue
+    fi
+    echo "Merge complete."
+  else
+    echo "[DRY RUN] Would run: $combine_script $team_day_dir"
+  fi
+
+  merged_count=$(find "$team_day_dir/merged_videos" -name 'PROCESSED*.MP4' 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$merged_count" -eq 0 ]; then
+    if [ "$dry_run" = true ]; then
+      echo "[DRY RUN] No merged videos yet — split will run after SD import and merge."
+    else
+      echo "No merged videos in $team_day_dir/merged_videos, skipping split."
+    fi
+    echo ""
+    continue
+  fi
+
+  games_jsonl=""
+  if [ -n "$schedule_dir" ]; then
+    games_jsonl="$schedule_dir/${day}_${team_slug}.jsonl"
+  fi
+
+  if [ -z "$games_jsonl" ] || [ ! -f "$games_jsonl" ]; then
+    echo "Warning: No schedule file for $team_label (expected ${day}_${team_slug}.jsonl)"
+    continue
+  fi
+
+  split_args=("$team_day_dir" "$games_jsonl" --tournament "$tournament_name")
+  if [ "$dry_run" = true ]; then
+    split_args+=(--debug)
+  fi
+
+  echo "Splitting matchups using $games_jsonl..."
+  if ! "$split_script" "${split_args[@]}"; then
+    echo "Error: split failed for $team_label"
+    continue
+  fi
+
+  split_count=$(find "$team_day_dir/split_videos" \( -name '*.mp4' -o -name '*.MP4' \) 2>/dev/null | wc -l | tr -d ' ')
+  echo "Done: $team_label ($split_count matchup files in split_videos/)"
+  echo ""
+done
+
+echo "=== Team Day Processing Complete ==="

--- a/src/bash/setup_team_folders.sh
+++ b/src/bash/setup_team_folders.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Create per-team day folders for team GoPro SD card footage.
+# Usage: setup_team_folders.sh [tournament_root] [--teams LIST]
+#
+# Example:
+#   ./setup_team_folders.sh src/output/June2026Tournament
+#   ./setup_team_folders.sh src/output/June2026Tournament --teams "Sister Sister,Fresh Prince"
+
+set -e
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+tournament_root="${1:-$repo_root/src/output/June2026Tournament}"
+teams_filter=""
+
+if [[ "$tournament_root" =~ \  ]]; then
+  echo "Error: Tournament path contains spaces."
+  exit 1
+fi
+
+shift || true
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --teams)
+      teams_filter="$2"
+      shift 2
+      ;;
+    -h|--help)
+      echo "Usage: $0 [tournament_root] [--teams \"Team A,Team B\"]"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+schedule_xlsx="$tournament_root/schedule/master_schedule.xlsx"
+if [ ! -f "$schedule_xlsx" ]; then
+  echo "Error: Schedule not found at $schedule_xlsx"
+  echo "Copy the Throw Down team schedules workbook there first."
+  exit 1
+fi
+
+python_bin="$repo_root/.venv/bin/python"
+if [ ! -x "$python_bin" ]; then
+  python_bin="python3"
+fi
+
+list_args=("$python_bin" "$repo_root/src/scripts/excel_team_schedule_to_jsonl.py" "$schedule_xlsx" --list-teams)
+if [ -n "$teams_filter" ]; then
+  list_args+=(--teams "$teams_filter")
+fi
+
+echo "=== Team Folder Setup ==="
+echo "Root: $tournament_root"
+echo ""
+
+mkdir -p "$tournament_root/teams"
+mkdir -p "$tournament_root/schedule/generated_teams"
+
+team_count=0
+while IFS=$'\t' read -r team_name team_slug; do
+  [ -n "$team_name" ] || continue
+  for day in 2026-06-20 2026-06-21; do
+    team_day_dir="$tournament_root/teams/$team_slug/$day"
+    mkdir -p "$team_day_dir/merged_videos" "$team_day_dir/split_videos"
+    notes_file="$team_day_dir/recording_notes.txt"
+    if [ ! -f "$notes_file" ]; then
+      cat > "$notes_file" << EOF
+# Recording notes — ${team_name} — ${day}
+# Log any camera stop/start events (battery swaps, angle adjustments, etc.)
+# Format: HH:MM — event description
+#
+# Example:
+# 09:00 — Round robin recording started
+# 12:05 — Stopped for lunch
+# 13:30 — Bracket play recording started
+# 14:15 — Battery swap (~2 min gap)
+EOF
+    fi
+  done
+  echo "  teams/${team_slug}/2026-06-20/"
+  echo "  teams/${team_slug}/2026-06-21/"
+  team_count=$((team_count + 1))
+done < <("${list_args[@]}")
+
+echo ""
+echo "Created folders for $team_count team(s)."
+echo ""
+echo "Next steps:"
+echo "  1. Generate team schedules:"
+echo "     .venv/bin/python src/scripts/excel_team_schedule_to_jsonl.py \\"
+echo "       $schedule_xlsx \\"
+echo "       --output-dir $tournament_root/schedule/generated_teams \\"
+echo "       --date 2026-06-20"
+echo "     (Re-run with --date 2026-06-21 when Sunday sheets are filled in)"
+echo "  2. Import team SD cards:"
+echo "     $script_dir/import_team_sd.sh \\"
+echo "       --dest $tournament_root/teams/sister_sister/2026-06-20 \\"
+echo "       --card Team-Sister-Sister-Sat"

--- a/src/bash/setup_tournament.sh
+++ b/src/bash/setup_tournament.sh
@@ -19,6 +19,7 @@ echo "Root: $tournament_root"
 echo ""
 
 mkdir -p "$tournament_root/schedule/generated"
+mkdir -p "$tournament_root/schedule/generated_teams"
 mkdir -p "$tournament_root/deliverables"
 
 for day_courts in "2026-06-20:2,3,4" "2026-06-21:2,3"; do
@@ -45,11 +46,32 @@ EOF
   done
 done
 
+# Team GoPro SD cards (Sister Sister)
+for day in 2026-06-20 2026-06-21; do
+  team_dir="$tournament_root/teams/sister_sister/$day"
+  mkdir -p "$team_dir/merged_videos" "$team_dir/split_videos"
+  notes_file="$team_dir/recording_notes.txt"
+  if [ ! -f "$notes_file" ]; then
+    cat > "$notes_file" << EOF
+# Recording notes — Sister Sister — ${day}
+# Log any camera stop/start events (battery swaps, angle adjustments, etc.)
+# Format: HH:MM — event description
+#
+# Example:
+# 09:00 — Round robin recording started
+# 12:05 — Stopped for lunch
+# 13:30 — Bracket play recording started
+# 14:15 — Battery swap (~2 min gap)
+EOF
+  fi
+done
+
 echo "Folder tree ready."
 echo ""
 echo "--- Court checklist ---"
 echo "Sat Jun 20: court2, court3, court4 (court1 streams — skip)"
 echo "Sun Jun 21: court2, court3 (court1 streams — skip)"
+echo "Team SD:    teams/sister_sister/2026-06-20 and 2026-06-21"
 echo ""
 
 missing=()
@@ -79,6 +101,9 @@ fi
 echo ""
 echo "Next steps:"
 echo "  1. Place schedule at $tournament_root/schedule/master_schedule.xlsx"
-echo "  2. python src/scripts/excel_schedule_to_jsonl.py <excel> --output-dir $tournament_root/schedule/generated"
+echo "  2. Court schedule:"
+echo "     python src/scripts/excel_schedule_to_jsonl.py <excel> --output-dir $tournament_root/schedule/generated"
 echo "     (Re-run with --date 2026-06-21 when Sunday bracket sheets are in the workbook)"
-echo "  3. $script_dir/validate_tournament_setup.sh --dry-run"
+echo "  3. Sister Sister team schedule:"
+echo "     python src/scripts/excel_team_schedule_to_jsonl.py <excel> --teams \"Sister Sister\" --output-dir $tournament_root/schedule/generated_teams --date 2026-06-20"
+echo "  4. $script_dir/validate_tournament_setup.sh --dry-run"

--- a/src/bash/split_game_videos.sh
+++ b/src/bash/split_game_videos.sh
@@ -198,6 +198,11 @@ for line in "${games[@]}"; do
   
   # Add team names
   team_names="${home_team} vs ${away_team}"
+  if [[ "$home_team" =~ ^[Tt][Bb][Dd]$ ]] || [[ "$away_team" =~ ^[Tt][Bb][Dd]$ ]]; then
+    if [ -n "$filename_parts" ]; then
+      filename_parts="${filename_parts}: ${start_time}"
+    fi
+  fi
   if [ -n "$filename_parts" ]; then
     filename_parts="${filename_parts}: ${team_names}"
   else

--- a/src/bash/split_multi_source_videos.sh
+++ b/src/bash/split_multi_source_videos.sh
@@ -207,6 +207,11 @@ while IFS= read -r line; do
   round=$(echo "$line" | jq -r '.round // ""')
   game_type=$(echo "$line" | jq -r '.type // "round_robin"')
   video_file=$(echo "$line" | jq -r '.video_file // ""')
+  game_court=$(echo "$line" | jq -r '.court // ""')
+  effective_court="$court_name"
+  if [ -n "$game_court" ] && [ "$game_court" != "null" ]; then
+    effective_court="$game_court"
+  fi
   
   # Skip if essential fields are missing
   if [ -z "$home_team" ] || [ -z "$away_team" ] || [ -z "$start_time" ] || [ -z "$minutes" ]; then
@@ -274,8 +279,8 @@ while IFS= read -r line; do
     filename_parts="Round ${round}"
   fi
 
-  if [ -n "$court_name" ]; then
-    formatted_court=$(echo "$court_name" | sed 's/_/ /g')
+  if [ -n "$effective_court" ]; then
+    formatted_court=$(echo "$effective_court" | sed 's/_/ /g')
     if [ -n "$filename_parts" ]; then
       filename_parts="${filename_parts}: ${formatted_court}"
     else
@@ -284,6 +289,11 @@ while IFS= read -r line; do
   fi
 
   team_names="${home_team} vs ${away_team}"
+  if [[ "$home_team" =~ ^[Tt][Bb][Dd]$ ]] || [[ "$away_team" =~ ^[Tt][Bb][Dd]$ ]]; then
+    if [ -n "$filename_parts" ]; then
+      filename_parts="${filename_parts}: ${start_time}"
+    fi
+  fi
   if [ -n "$filename_parts" ]; then
     filename_parts="${filename_parts}: ${team_names}"
   else
@@ -292,7 +302,7 @@ while IFS= read -r line; do
 
   if [ -n "$tournament_name" ] && [ -n "$filename_parts" ]; then
     output_filename="${filename_parts}.mp4"
-  elif [ -n "$court_name" ] && [ -n "$filename_parts" ]; then
+  elif [ -n "$effective_court" ] && [ -n "$filename_parts" ]; then
     output_filename="${filename_parts}.mp4"
   else
     output_filename="${home_team_formatted}_vs_${away_team_formatted}.mp4"

--- a/src/output/June2026Tournament/schedule/bracket_teams.example.json
+++ b/src/output/June2026Tournament/schedule/bracket_teams.example.json
@@ -1,0 +1,8 @@
+[
+  {
+    "start_time": "14:40",
+    "court": "Court 2",
+    "home_team": "Sister Sister",
+    "away_team": "Static Shock"
+  }
+]

--- a/src/output/June2026Tournament/schedule/generated/2026-06-20_court2.jsonl
+++ b/src/output/June2026Tournament/schedule/generated/2026-06-20_court2.jsonl
@@ -8,3 +8,11 @@
 {"type": "round_robin", "round": "Round 8", "home_team": "Fresh Prince", "away_team": "Smart Guy", "start_time": "12:05", "minutes": 25, "court": "Court 2"}
 {"type": "round_robin", "round": "Round 9", "home_team": "Black Panther", "away_team": "The Parkers", "start_time": "12:30", "minutes": 25, "court": "Court 2"}
 {"type": "round_robin", "round": "Round 10", "home_team": "Thats So Raven", "away_team": "Abbott Elementary", "start_time": "12:55", "minutes": 25, "court": "Court 2"}
+{"type": "bracket", "round": "Round 1", "home_team": "TBD", "away_team": "TBD", "start_time": "13:50", "minutes": 25, "court": "Court 2"}
+{"type": "bracket", "round": "Round 1", "home_team": "TBD", "away_team": "TBD", "start_time": "14:15", "minutes": 25, "court": "Court 2"}
+{"type": "bracket", "round": "Quarters", "home_team": "TBD", "away_team": "TBD", "start_time": "14:40", "minutes": 25, "court": "Court 2"}
+{"type": "bracket", "round": "Quarters", "home_team": "TBD", "away_team": "TBD", "start_time": "15:05", "minutes": 25, "court": "Court 2"}
+{"type": "bracket", "round": "Semis", "home_team": "TBD", "away_team": "TBD", "start_time": "15:30", "minutes": 25, "court": "Court 2"}
+{"type": "bracket", "round": "Semis", "home_team": "TBD", "away_team": "TBD", "start_time": "15:55", "minutes": 25, "court": "Court 2"}
+{"type": "bracket", "round": "Finals", "home_team": "TBD", "away_team": "TBD", "start_time": "16:20", "minutes": 25, "court": "Court 2"}
+{"type": "bracket", "round": "Championship", "home_team": "TBD", "away_team": "TBD", "start_time": "16:45", "minutes": 25, "court": "Court 2"}

--- a/src/output/June2026Tournament/schedule/generated/2026-06-20_court3.jsonl
+++ b/src/output/June2026Tournament/schedule/generated/2026-06-20_court3.jsonl
@@ -8,3 +8,11 @@
 {"type": "round_robin", "round": "Round 8", "home_team": "The Incredibles", "away_team": "Thats So Raven", "start_time": "12:05", "minutes": 25, "court": "Court 3"}
 {"type": "round_robin", "round": "Round 9", "home_team": "Family Matters", "away_team": "Smart Guy", "start_time": "12:30", "minutes": 25, "court": "Court 3"}
 {"type": "round_robin", "round": "Round 10", "home_team": "The Boondocks", "away_team": "Fresh Prince", "start_time": "12:55", "minutes": 25, "court": "Court 3"}
+{"type": "bracket", "round": "Round 1", "home_team": "TBD", "away_team": "TBD", "start_time": "13:50", "minutes": 25, "court": "Court 3"}
+{"type": "bracket", "round": "Round 1", "home_team": "TBD", "away_team": "TBD", "start_time": "14:15", "minutes": 25, "court": "Court 3"}
+{"type": "bracket", "round": "Quarters", "home_team": "TBD", "away_team": "TBD", "start_time": "14:40", "minutes": 25, "court": "Court 3"}
+{"type": "bracket", "round": "Quarters", "home_team": "TBD", "away_team": "TBD", "start_time": "15:05", "minutes": 25, "court": "Court 3"}
+{"type": "bracket", "round": "Semis", "home_team": "TBD", "away_team": "TBD", "start_time": "15:30", "minutes": 25, "court": "Court 3"}
+{"type": "bracket", "round": "Semis", "home_team": "TBD", "away_team": "TBD", "start_time": "15:55", "minutes": 25, "court": "Court 3"}
+{"type": "bracket", "round": "Finals", "home_team": "TBD", "away_team": "TBD", "start_time": "16:20", "minutes": 25, "court": "Court 3"}
+{"type": "bracket", "round": "Championship", "home_team": "TBD", "away_team": "TBD", "start_time": "16:45", "minutes": 25, "court": "Court 3"}

--- a/src/output/June2026Tournament/schedule/generated/2026-06-20_court4.jsonl
+++ b/src/output/June2026Tournament/schedule/generated/2026-06-20_court4.jsonl
@@ -8,3 +8,11 @@
 {"type": "round_robin", "round": "Round 8", "home_team": "Proud Family", "away_team": "The Parkers", "start_time": "12:05", "minutes": 25, "court": "Court 4"}
 {"type": "round_robin", "round": "Round 9", "home_team": "Sister Sister", "away_team": "Kenan & Kel", "start_time": "12:30", "minutes": 25, "court": "Court 4"}
 {"type": "round_robin", "round": "Round 10", "home_team": "Proud Family", "away_team": "The Cleveland Show", "start_time": "12:55", "minutes": 25, "court": "Court 4"}
+{"type": "bracket", "round": "Round 1", "home_team": "TBD", "away_team": "TBD", "start_time": "13:50", "minutes": 25, "court": "Court 4"}
+{"type": "bracket", "round": "Round 1", "home_team": "TBD", "away_team": "TBD", "start_time": "14:15", "minutes": 25, "court": "Court 4"}
+{"type": "bracket", "round": "Quarters", "home_team": "TBD", "away_team": "TBD", "start_time": "14:40", "minutes": 25, "court": "Court 4"}
+{"type": "bracket", "round": "Quarters", "home_team": "TBD", "away_team": "TBD", "start_time": "15:05", "minutes": 25, "court": "Court 4"}
+{"type": "bracket", "round": "Semis", "home_team": "TBD", "away_team": "TBD", "start_time": "15:30", "minutes": 25, "court": "Court 4"}
+{"type": "bracket", "round": "Semis", "home_team": "TBD", "away_team": "TBD", "start_time": "15:55", "minutes": 25, "court": "Court 4"}
+{"type": "bracket", "round": "Finals", "home_team": "TBD", "away_team": "TBD", "start_time": "16:20", "minutes": 25, "court": "Court 4"}
+{"type": "bracket", "round": "Championship", "home_team": "TBD", "away_team": "TBD", "start_time": "16:45", "minutes": 25, "court": "Court 4"}

--- a/src/output/June2026Tournament/schedule/generated_teams/2026-06-20_sister_sister.jsonl
+++ b/src/output/June2026Tournament/schedule/generated_teams/2026-06-20_sister_sister.jsonl
@@ -1,0 +1,5 @@
+{"type": "round_robin", "round": "Round 2", "home_team": "Sister Sister", "away_team": "Static Shock", "start_time": "09:25", "minutes": 25, "court": "Court 2", "team": "Sister Sister"}
+{"type": "round_robin", "round": "Round 3", "home_team": "Fresh Prince", "away_team": "Sister Sister", "start_time": "10:00", "minutes": 25, "court": "Court 1", "team": "Sister Sister"}
+{"type": "round_robin", "round": "Round 6", "home_team": "Family Matters", "away_team": "Sister Sister", "start_time": "11:15", "minutes": 25, "court": "Court 3", "team": "Sister Sister"}
+{"type": "round_robin", "round": "Round 7", "home_team": "Sister Sister", "away_team": "Martin", "start_time": "11:40", "minutes": 25, "court": "Court 1", "team": "Sister Sister"}
+{"type": "round_robin", "round": "Round 9", "home_team": "Sister Sister", "away_team": "Kenan & Kel", "start_time": "12:30", "minutes": 25, "court": "Court 4", "team": "Sister Sister"}

--- a/src/output/June2026Tournament/teams/sister_sister/2026-06-20/recording_notes.txt
+++ b/src/output/June2026Tournament/teams/sister_sister/2026-06-20/recording_notes.txt
@@ -1,0 +1,9 @@
+# Recording notes — Sister Sister — 2026-06-20
+# Log any camera stop/start events (battery swaps, angle adjustments, etc.)
+# Format: HH:MM — event description
+#
+# Example:
+# 09:00 — Round robin recording started
+# 12:05 — Stopped for lunch
+# 13:30 — Bracket play recording started
+# 14:15 — Battery swap (~2 min gap)

--- a/src/output/June2026Tournament/teams/sister_sister/2026-06-21/recording_notes.txt
+++ b/src/output/June2026Tournament/teams/sister_sister/2026-06-21/recording_notes.txt
@@ -1,0 +1,9 @@
+# Recording notes — Sister Sister — 2026-06-21
+# Log any camera stop/start events (battery swaps, angle adjustments, etc.)
+# Format: HH:MM — event description
+#
+# Example:
+# 09:00 — Round robin recording started
+# 12:05 — Stopped for lunch
+# 13:30 — Bracket play recording started
+# 14:15 — Battery swap (~2 min gap)

--- a/src/scripts/excel_schedule_to_jsonl.py
+++ b/src/scripts/excel_schedule_to_jsonl.py
@@ -21,6 +21,8 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+from throwdown_bracket import build_bracket_time_map, classify_game, merge_bracket_games
+
 try:
     import openpyxl
 except ImportError:
@@ -185,8 +187,25 @@ def parse_table_sheet(sheet):
     return games
 
 
-def parse_throwdown_workbook(workbook, date, skip_courts, minutes):
+def parse_throwdown_workbook(workbook, date, skip_courts, minutes, include_bracket_placeholders=True, active_courts=None):
     aliases = build_team_aliases(workbook)
+    round_robin_games = _parse_throwdown_team_sheet_games(workbook, date, skip_courts, minutes, aliases)
+    merged, bracket_start, overview_count, bracket_count = merge_bracket_games(
+        round_robin_games,
+        workbook,
+        date,
+        skip_courts,
+        minutes,
+        aliases,
+        resolve_team_name,
+        include_placeholders=include_bracket_placeholders,
+        active_courts=active_courts,
+    )
+    return merged, bracket_start, overview_count, bracket_count
+
+
+def _parse_throwdown_team_sheet_games(workbook, date, skip_courts, minutes, aliases):
+    bracket_start, bracket_time_map = build_bracket_time_map(workbook, date)
     games = []
     seen = set()
 
@@ -227,6 +246,13 @@ def parse_throwdown_workbook(workbook, date, skip_courts, minutes):
                 continue
 
             round_num = int(round_val)
+            game_type, round_label = classify_game(
+                start_time,
+                round_num,
+                bracket_start,
+                bracket_time_map,
+                bracket_minutes=minutes,
+            )
             dedupe_key = (round_num, start_time, court_num, home_team, away_team)
             if dedupe_key in seen:
                 continue
@@ -236,8 +262,8 @@ def parse_throwdown_workbook(workbook, date, skip_courts, minutes):
                 "date": date,
                 "court": f"court{court_num}",
                 "court_display": f"Court {court_num}",
-                "type": "round_robin",
-                "round": f"Round {round_num}",
+                "type": game_type,
+                "round": round_label,
                 "home_team": home_team,
                 "away_team": away_team,
                 "start_time": start_time,
@@ -324,6 +350,16 @@ def main():
         default=None,
         help="Copy source Excel to this path (e.g. schedule/master_schedule.xlsx)",
     )
+    parser.add_argument(
+        "--no-bracket-placeholders",
+        action="store_true",
+        help="Skip TBD bracket slots (default: include placeholder games per court/time)",
+    )
+    parser.add_argument(
+        "--active-courts",
+        default=None,
+        help="Courts with GoPro SD cards, e.g. 2,3,4 (default: date-based 2-4 Sat, 2-3 Sun)",
+    )
     args = parser.parse_args()
 
     excel_path = Path(args.excel_file)
@@ -340,10 +376,27 @@ def main():
     workbook = openpyxl.load_workbook(excel_path, read_only=True, data_only=True)
     fmt = args.format if args.format != "auto" else detect_format(workbook)
     skip_courts = parse_skip_courts(args.skip_courts)
+    active_courts = None
+    if args.active_courts:
+        active_courts = [int(part.strip()) for part in args.active_courts.split(",") if part.strip()]
 
     if fmt == "throwdown":
-        all_games = parse_throwdown_workbook(workbook, args.date, skip_courts, args.minutes)
-        print(f"Parsed {len(all_games)} games from throwdown team sheets (skipped courts: {sorted(skip_courts)})")
+        all_games, bracket_start, overview_count, bracket_count = parse_throwdown_workbook(
+            workbook,
+            args.date,
+            skip_courts,
+            args.minutes,
+            include_bracket_placeholders=not args.no_bracket_placeholders,
+            active_courts=active_courts,
+        )
+        rr_count = sum(1 for g in all_games if g["type"] == "round_robin")
+        br_count = sum(1 for g in all_games if g["type"] == "bracket")
+        print(
+            f"Parsed {len(all_games)} games ({rr_count} round robin, {br_count} bracket) "
+            f"from {bracket_start}"
+        )
+        if overview_count:
+            print(f"  {overview_count} bracket matchup(s) from Overview Schedule")
     else:
         sheets = [workbook[args.sheet]] if args.sheet else workbook.worksheets
         all_games = []

--- a/src/scripts/excel_team_schedule_to_jsonl.py
+++ b/src/scripts/excel_team_schedule_to_jsonl.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+Convert Throw Down team sheets into per-team games.jsonl files.
+
+Each team sheet lists PLAYING assignments (HOME, AWAY, or stream court).
+Unlike the court converter, this includes every game a team plays — including
+Court 1 stream matchups and AWAY assignments.
+
+Output files: {date}_{team_slug}.jsonl in the output directory.
+
+Usage:
+  python excel_team_schedule_to_jsonl.py schedule/master_schedule.xlsx \\
+    --output-dir src/output/June2026Tournament/schedule/generated_teams
+"""
+
+import argparse
+import json
+import re
+import shutil
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+try:
+    import openpyxl
+except ImportError:
+    print("Error: openpyxl is required. Install with: pip install openpyxl", file=sys.stderr)
+    sys.exit(1)
+
+from excel_schedule_to_jsonl import (
+    THROWDOWN_SKIP_SHEETS,
+    build_team_aliases,
+    normalize_time,
+    resolve_team_name,
+)
+from throwdown_bracket import build_bracket_time_map, classify_game
+
+
+PLAYING_RE = re.compile(
+    r"PLAYING\s*:\s*Court\s*(\d+)\s*(?:\([^)]*\))?\s*vs\.?\s*(.+)",
+    re.I,
+)
+
+
+def team_slug(name):
+    return re.sub(r"[^a-z0-9]+", "_", str(name).lower()).strip("_")
+
+
+def playing_role(assignment):
+    upper = assignment.upper()
+    if "(HOME)" in upper or "STREAM COURT - HOME" in upper:
+        return "home"
+    if "(AWAY)" in upper or "STREAM COURT - AWAY" in upper:
+        return "away"
+    return "home"
+
+
+def list_team_sheets(workbook, teams_filter=None):
+    sheets = []
+    for sheet_name in workbook.sheetnames:
+        if sheet_name in THROWDOWN_SKIP_SHEETS:
+            continue
+        if teams_filter and team_slug(sheet_name) not in teams_filter:
+            slug_names = {team_slug(t) for t in teams_filter}
+            if team_slug(sheet_name) not in slug_names:
+                # Also allow matching by display name
+                if sheet_name not in teams_filter:
+                    continue
+        sheets.append(sheet_name)
+    return sheets
+
+
+def parse_team_sheet(workbook, sheet_name, date, minutes, aliases, bracket_start, bracket_time_map):
+    games = []
+    seen = set()
+
+    for row in workbook[sheet_name].iter_rows(values_only=True):
+        if not row or len(row) < 3:
+            continue
+        assignment = row[2]
+        if not assignment or not isinstance(assignment, str):
+            continue
+        if "PLAYING" not in assignment.upper():
+            continue
+
+        match = PLAYING_RE.search(assignment)
+        if not match:
+            continue
+
+        court_num = int(match.group(1))
+        opponent = resolve_team_name(match.group(2).strip(), aliases)
+        role = playing_role(assignment)
+
+        round_val = row[0]
+        time_val = row[1]
+        if round_val is None or time_val is None:
+            continue
+
+        start_time = normalize_time(time_val)
+        if not start_time:
+            continue
+
+        round_num = int(round_val)
+        game_type, round_label = classify_game(
+            start_time,
+            round_num,
+            bracket_start,
+            bracket_time_map,
+            bracket_minutes=minutes,
+        )
+        if role == "home":
+            home_team = sheet_name
+            away_team = opponent
+        else:
+            home_team = opponent
+            away_team = sheet_name
+
+        dedupe_key = (round_num, start_time, court_num, home_team, away_team)
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+
+        games.append({
+            "date": date,
+            "team": sheet_name,
+            "team_slug": team_slug(sheet_name),
+            "court": f"court{court_num}",
+            "court_display": f"Court {court_num}",
+            "type": game_type,
+            "round": round_label,
+            "home_team": home_team,
+            "away_team": away_team,
+            "start_time": start_time,
+            "minutes": minutes,
+        })
+
+    games.sort(key=lambda g: (g["start_time"], g["round"]))
+    return games
+
+
+def write_team_jsonl_files(games, output_dir):
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    grouped = defaultdict(list)
+    for game in games:
+        key = (game["date"], game["team_slug"])
+        grouped[key].append(game)
+
+    written = []
+    for (date, slug), team_games in sorted(grouped.items()):
+        outfile = output_dir / f"{date}_{slug}.jsonl"
+        with open(outfile, "w") as f:
+            for game in team_games:
+                record = {
+                    "type": game.get("type", "round_robin"),
+                    "round": game.get("round", ""),
+                    "home_team": game["home_team"],
+                    "away_team": game["away_team"],
+                    "start_time": game["start_time"],
+                    "minutes": game["minutes"],
+                    "court": game["court_display"],
+                    "team": game["team"],
+                }
+                f.write(json.dumps(record) + "\n")
+        written.append(outfile)
+        print(f"Wrote {len(team_games)} games to {outfile}")
+
+    return written
+
+
+def parse_teams_filter(value):
+    if not value:
+        return None
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert Throw Down team sheets to per-team games.jsonl files"
+    )
+    parser.add_argument("excel_file", help="Path to tournament schedule .xlsx")
+    parser.add_argument(
+        "--output-dir",
+        default="src/output/June2026Tournament/schedule/generated_teams",
+        help="Directory for generated team JSONL files",
+    )
+    parser.add_argument(
+        "--date",
+        default="2026-06-20",
+        help="Tournament date for team sheets (default: 2026-06-20)",
+    )
+    parser.add_argument(
+        "--minutes",
+        type=int,
+        default=25,
+        help="Game duration in minutes (default: 25)",
+    )
+    parser.add_argument(
+        "--teams",
+        default=None,
+        help="Comma-separated team names or slugs (default: all team sheets)",
+    )
+    parser.add_argument(
+        "--copy-to",
+        default=None,
+        help="Copy source Excel to this path (e.g. schedule/master_schedule.xlsx)",
+    )
+    parser.add_argument(
+        "--list-teams",
+        action="store_true",
+        help="Print team sheet names and slugs, then exit",
+    )
+    parser.add_argument(
+        "--bracket-start",
+        default=None,
+        help="Wall-clock bracket start (default: detect from workbook or date defaults)",
+    )
+    parser.add_argument(
+        "--round-robin-max",
+        type=int,
+        default=10,
+        help="Highest round-robin round number before times imply bracket (default: 10)",
+    )
+    args = parser.parse_args()
+
+    excel_path = Path(args.excel_file)
+    if not excel_path.exists():
+        print(f"Error: Excel file not found: {excel_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.copy_to:
+        copy_dest = Path(args.copy_to)
+        copy_dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(excel_path, copy_dest)
+        print(f"Copied schedule to {copy_dest}")
+
+    workbook = openpyxl.load_workbook(excel_path, read_only=True, data_only=True)
+    teams_filter = parse_teams_filter(args.teams)
+    team_sheets = list_team_sheets(workbook, teams_filter)
+
+    if args.list_teams:
+        for name in team_sheets:
+            print(f"{name}\t{team_slug(name)}")
+        return
+
+    if not team_sheets:
+        print("Error: No team sheets matched.", file=sys.stderr)
+        sys.exit(1)
+
+    aliases = build_team_aliases(workbook)
+    bracket_start, bracket_time_map = build_bracket_time_map(workbook, args.date)
+    if args.bracket_start:
+        bracket_start = normalize_time(args.bracket_start) or args.bracket_start
+    print(f"Bracket start: {bracket_start} ({len(bracket_time_map)} known slot(s))")
+
+    all_games = []
+    for sheet_name in team_sheets:
+        games = parse_team_sheet(
+            workbook,
+            sheet_name,
+            args.date,
+            args.minutes,
+            aliases,
+            bracket_start,
+            bracket_time_map,
+        )
+        all_games.extend(games)
+        print(f"Parsed {len(games)} games for {sheet_name}")
+
+    if not all_games:
+        print("Error: No games parsed from team sheets.", file=sys.stderr)
+        sys.exit(1)
+
+    write_team_jsonl_files(all_games, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/fill_bracket_teams.py
+++ b/src/scripts/fill_bracket_teams.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Fill in bracket team names after seeding and optionally rename split videos.
+
+Match games by court + start_time. TBD placeholder files include the start time
+in the filename (e.g. Bracket Quarters: Court 2: 14:40: TBD vs TBD.mp4).
+
+Usage:
+  python fill_bracket_teams.py \\
+    --jsonl schedule/generated/2026-06-20_court2.jsonl \\
+    --updates bracket_teams.json \\
+    --split-dir src/output/June2026Tournament/2026-06-20/court2/split_videos \\
+    --rename
+
+updates JSON format:
+[
+  {
+    "start_time": "14:40",
+    "court": "Court 2",
+    "home_team": "Sister Sister",
+    "away_team": "Static Shock"
+  }
+]
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from game_filename import build_matchup_filename, is_placeholder_team
+
+
+def load_jsonl(path):
+    games = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                games.append(json.loads(line))
+    return games
+
+
+def write_jsonl(path, games):
+    with open(path, "w") as f:
+        for game in games:
+            f.write(json.dumps(game) + "\n")
+
+
+def match_key(game):
+    court = game.get("court") or game.get("court_display") or ""
+    return (game["start_time"], court.strip().lower())
+
+
+def apply_updates(games, updates):
+    by_key = {match_key(game): game for game in games}
+    pairs = []
+    for update in updates:
+        key = (update["start_time"], update["court"].strip().lower())
+        if key not in by_key:
+            print(f"Warning: no game for {update['court']} at {update['start_time']}", file=sys.stderr)
+            continue
+        game = by_key[key]
+        old_snapshot = dict(game)
+        game["home_team"] = update["home_team"]
+        game["away_team"] = update["away_team"]
+        if update.get("round"):
+            game["round"] = update["round"]
+        if update.get("type"):
+            game["type"] = update["type"]
+        pairs.append((old_snapshot, game))
+    print(f"Updated {len(pairs)} game(s)")
+    return pairs
+
+
+def rename_split_videos(renames, split_dir, dry_run=False):
+    split_dir = Path(split_dir)
+    for old_name, new_name in renames:
+        old_path = split_dir / old_name
+        new_path = split_dir / new_name
+        if old_name == new_name:
+            continue
+        if not old_path.exists():
+            print(f"Warning: split video not found: {old_path}", file=sys.stderr)
+            continue
+        if new_path.exists():
+            print(f"Warning: target already exists, skipping: {new_path}", file=sys.stderr)
+            continue
+        if dry_run:
+            print(f"Would rename: {old_name} -> {new_name}")
+        else:
+            old_path.rename(new_path)
+            print(f"Renamed: {old_name} -> {new_name}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fill bracket team names in games.jsonl")
+    parser.add_argument("--jsonl", required=True, help="Per-court games.jsonl to update")
+    parser.add_argument("--updates", required=True, help="JSON file with team updates")
+    parser.add_argument("--split-dir", default=None, help="split_videos/ folder to rename")
+    parser.add_argument("--rename", action="store_true", help="Rename split videos to match new team names")
+    parser.add_argument("--dry-run", action="store_true", help="Preview renames without writing")
+    args = parser.parse_args()
+
+    jsonl_path = Path(args.jsonl)
+    updates_path = Path(args.updates)
+    if not jsonl_path.exists():
+        print(f"Error: JSONL not found: {jsonl_path}", file=sys.stderr)
+        sys.exit(1)
+    if not updates_path.exists():
+        print(f"Error: updates file not found: {updates_path}", file=sys.stderr)
+        sys.exit(1)
+
+    with open(updates_path) as f:
+        updates = json.load(f)
+    if not isinstance(updates, list):
+        print("Error: updates file must be a JSON array", file=sys.stderr)
+        sys.exit(1)
+
+    games = load_jsonl(jsonl_path)
+    pairs = apply_updates(games, updates)
+    renames = []
+    for old_game, new_game in pairs:
+        if args.rename and args.split_dir:
+            renames.append((build_matchup_filename(old_game), build_matchup_filename(new_game)))
+
+    if not args.dry_run:
+        write_jsonl(jsonl_path, games)
+        print(f"Wrote {jsonl_path}")
+    else:
+        print(f"[DRY RUN] Would write {jsonl_path}")
+
+    if args.rename and args.split_dir:
+        rename_split_videos(renames, args.split_dir, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/game_filename.py
+++ b/src/scripts/game_filename.py
@@ -1,0 +1,36 @@
+"""Build matchup video filenames to match split_multi_source_videos.sh output."""
+
+
+def _title_case_words(text):
+    return " ".join(word[:1].upper() + word[1:].lower() for word in str(text).replace("_", " ").split())
+
+
+def is_placeholder_team(name):
+    if name is None:
+        return True
+    return str(name).strip().upper() in {"", "TBD", "TBA", "TBC"}
+
+
+def build_matchup_filename(game):
+    parts = []
+    game_type = game.get("type") or ""
+    round_label = game.get("round") or ""
+
+    if game_type and round_label:
+        parts.append(f"{_title_case_words(game_type)} {round_label}")
+    elif round_label:
+        parts.append(f"Round {round_label}")
+
+    court = game.get("court") or game.get("court_display")
+    if court:
+        parts.append(str(court).replace("_", " "))
+
+    home_team = game.get("home_team", "")
+    away_team = game.get("away_team", "")
+    if is_placeholder_team(home_team) or is_placeholder_team(away_team):
+        start_time = game.get("start_time")
+        if start_time:
+            parts.append(str(start_time))
+
+    parts.append(f"{home_team} vs {away_team}")
+    return ": ".join(parts) + ".mp4"

--- a/src/scripts/throwdown_bracket.py
+++ b/src/scripts/throwdown_bracket.py
@@ -1,0 +1,381 @@
+"""
+Throw Down bracket round inference from wall-clock start times.
+
+Bracket games use type=bracket and round names like Quarters / Semis so split
+output filenames look like:
+  Bracket Quarters: Court 2: Sister Sister vs Static Shock.mp4
+"""
+
+from __future__ import annotations
+
+import re
+
+THROWDOWN_SKIP_SHEETS = {"Overview Schedule", "BOARD Schedule", "BLANK"}
+
+BRACKET_ROUND_SEQUENCE = [
+    "Round 1",
+    "Round 1",
+    "Quarters",
+    "Quarters",
+    "Semis",
+    "Semis",
+    "Finals",
+    "Finals",
+    "Championship",
+]
+
+# Saturday bracket slots (25-minute rhythm from 13:50). Merged with Overview
+# Schedule rows when bracket matchups are filled in.
+DEFAULT_SATURDAY_BRACKET_SLOTS = {
+    "13:50": "Round 1",
+    "14:15": "Round 1",
+    "14:40": "Quarters",
+    "15:05": "Quarters",
+    "15:30": "Semis",
+    "15:55": "Semis",
+    "16:20": "Finals",
+    "16:45": "Championship",
+}
+
+DEFAULT_SUNDAY_BRACKET_SLOTS = {
+    "09:00": "Round 1",
+    "09:25": "Round 1",
+    "09:50": "Quarters",
+    "10:15": "Quarters",
+    "10:40": "Semis",
+    "11:05": "Semis",
+    "11:30": "Finals",
+    "11:55": "Championship",
+}
+
+DEFAULT_BRACKET_START_BY_DATE = {
+    "2026-06-20": "13:50",
+    "2026-06-21": "09:00",
+}
+
+DEFAULT_SLOTS_BY_DATE = {
+    "2026-06-20": DEFAULT_SATURDAY_BRACKET_SLOTS,
+    "2026-06-21": DEFAULT_SUNDAY_BRACKET_SLOTS,
+}
+
+DEFAULT_ACTIVE_COURTS_BY_DATE = {
+    "2026-06-20": [2, 3, 4],
+    "2026-06-21": [2, 3],
+}
+
+OVERVIEW_COURT_COLUMNS = {
+    2: 1,
+    4: 2,
+    6: 3,
+    8: 4,
+}
+
+BRACKET_PLACEHOLDER = "TBD"
+
+BRACKET_MARKER_RE = re.compile(r"START OF BRACKET", re.I)
+ROUND_LABEL_RE = re.compile(
+    r"^(Round\s*1|Quarters?|Semis?|Semifinals?|Finals?|Championship|3rd Place|Third Place)$",
+    re.I,
+)
+
+
+def normalize_time(value):
+    if value is None or str(value).strip() == "":
+        return None
+    if hasattr(value, "strftime"):
+        return value.strftime("%H:%M")
+    text = str(value).strip()
+    if re.match(r"^\d{1,2}:\d{2}(:\d{2})?$", text):
+        parts = text.split(":")
+        if len(parts) == 2:
+            return f"{int(parts[0]):02d}:{parts[1]}"
+        return f"{int(parts[0]):02d}:{parts[1]}:{parts[2]}"
+    return text
+
+
+def time_to_minutes(time_str):
+    parts = str(time_str).split(":")
+    hours = int(parts[0])
+    minutes = int(parts[1]) if len(parts) > 1 else 0
+    return hours * 60 + minutes
+
+
+def detect_bracket_start(workbook, date):
+    found = None
+    for sheet_name in workbook.sheetnames:
+        if sheet_name in THROWDOWN_SKIP_SHEETS:
+            continue
+        for row in workbook[sheet_name].iter_rows(values_only=True):
+            if not row or len(row) < 3:
+                continue
+            assignment = row[2]
+            if not assignment or not isinstance(assignment, str):
+                continue
+            if not BRACKET_MARKER_RE.search(assignment):
+                continue
+            start = normalize_time(row[1])
+            if start:
+                found = start
+    return found or DEFAULT_BRACKET_START_BY_DATE.get(date, "13:50")
+
+
+def _normalize_round_label(value):
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text or text.lower() in {"round", "time"}:
+        return None
+    if ROUND_LABEL_RE.match(text):
+        if text.lower().startswith("quarter"):
+            return "Quarters"
+        if text.lower().startswith("semi"):
+            return "Semis"
+        if text.lower() == "finals":
+            return "Finals"
+        if "third" in text.lower() or "3rd" in text.lower():
+            return "Third Place"
+        if text.lower() == "championship":
+            return "Championship"
+        if re.match(r"^Round\s*1$", text, re.I):
+            return "Round 1"
+        return text
+    if re.match(r"^Round\s+\d+$", text, re.I) and not text.lower().startswith("round 1"):
+        return None
+    return None
+
+
+def parse_overview_bracket_map(workbook):
+    """Build start_time -> bracket round from Overview Schedule bracket rows."""
+    time_map = {}
+    bracket_start = None
+    current_round = None
+
+    if "Overview Schedule" not in workbook.sheetnames:
+        return bracket_start, time_map
+
+    in_bracket = False
+    for row in workbook["Overview Schedule"].iter_rows(values_only=True):
+        if not row:
+            continue
+
+        assignment = row[2] if len(row) > 2 else None
+        if assignment and isinstance(assignment, str) and BRACKET_MARKER_RE.search(assignment):
+            bracket_start = normalize_time(row[1]) or bracket_start
+            in_bracket = True
+            continue
+
+        if not in_bracket:
+            continue
+
+        round_label = _normalize_round_label(row[0])
+        if round_label:
+            current_round = round_label
+
+        start_time = normalize_time(row[1])
+        if start_time and current_round:
+            time_map[start_time] = current_round
+
+        if assignment and isinstance(assignment, str):
+            inline = _normalize_round_label(assignment)
+            if inline and start_time:
+                time_map[start_time] = inline
+
+    return bracket_start, time_map
+
+
+def build_bracket_time_map(workbook, date):
+    overview_start, overview_map = parse_overview_bracket_map(workbook)
+    bracket_start = overview_start or detect_bracket_start(workbook, date)
+    defaults = dict(DEFAULT_SLOTS_BY_DATE.get(date, DEFAULT_SATURDAY_BRACKET_SLOTS))
+    defaults.update(overview_map)
+    return bracket_start, defaults
+
+
+def lookup_bracket_round(start_time, time_map, bracket_start, bracket_minutes=25):
+    if start_time in time_map:
+        return time_map[start_time]
+
+    target = time_to_minutes(start_time)
+    best_round = None
+    best_distance = 9999
+    for slot_time, round_name in time_map.items():
+        distance = abs(target - time_to_minutes(slot_time))
+        if distance < best_distance:
+            best_distance = distance
+            best_round = round_name
+
+    tolerance = max(12, bracket_minutes // 2)
+    if best_round and best_distance <= tolerance:
+        return best_round
+
+    elapsed = round((target - time_to_minutes(bracket_start)) / bracket_minutes)
+    if 0 <= elapsed < len(BRACKET_ROUND_SEQUENCE):
+        return BRACKET_ROUND_SEQUENCE[elapsed]
+    if elapsed >= 0:
+        return BRACKET_ROUND_SEQUENCE[-1]
+    return "Round 1"
+
+
+def classify_game(start_time, round_num, bracket_start, time_map, bracket_minutes=25, round_robin_max=10):
+    """
+    Return (type, round) for JSONL output.
+
+    Round robin keeps Round N through round_robin_max; later times or explicit
+    bracket slots become type=bracket with Quarters / Semis / etc.
+    """
+    if time_to_minutes(start_time) < time_to_minutes(bracket_start):
+        return "round_robin", f"Round {round_num}"
+
+    if round_num is not None and round_num > round_robin_max:
+        bracket_round = lookup_bracket_round(start_time, time_map, bracket_start, bracket_minutes)
+        return "bracket", bracket_round
+
+    bracket_round = lookup_bracket_round(start_time, time_map, bracket_start, bracket_minutes)
+    return "bracket", bracket_round
+
+
+def is_placeholder_team(name):
+    if name is None:
+        return True
+    text = str(name).strip().upper()
+    return text in {"", "TBD", "TBA", "TBC"}
+
+
+def active_courts_for_date(date, skip_courts, active_courts=None):
+    if active_courts:
+        return [c for c in active_courts if c not in skip_courts]
+    courts = DEFAULT_ACTIVE_COURTS_BY_DATE.get(date, [2, 3, 4])
+    return [c for c in courts if c not in skip_courts]
+
+
+def game_slot_key(start_time, court_num):
+    return (start_time, court_num)
+
+
+def generate_bracket_placeholder_games(date, active_court_nums, bracket_time_map, bracket_start, minutes):
+    games = []
+    for start_time in sorted(bracket_time_map.keys()):
+        if time_to_minutes(start_time) < time_to_minutes(bracket_start):
+            continue
+        round_label = bracket_time_map[start_time]
+        for court_num in active_court_nums:
+            games.append({
+                "date": date,
+                "court": f"court{court_num}",
+                "court_display": f"Court {court_num}",
+                "type": "bracket",
+                "round": round_label,
+                "home_team": BRACKET_PLACEHOLDER,
+                "away_team": BRACKET_PLACEHOLDER,
+                "start_time": start_time,
+                "minutes": minutes,
+            })
+    return games
+
+
+def parse_overview_bracket_games(workbook, date, skip_courts, minutes, aliases, bracket_start, bracket_time_map, resolve_team_name):
+    """Parse bracket matchups from Overview Schedule when team names are filled in."""
+    games = []
+    if "Overview Schedule" not in workbook.sheetnames:
+        return games
+
+    in_bracket = False
+    pending_homes = {}
+    current_start = None
+    current_round = None
+
+    for row in workbook["Overview Schedule"].iter_rows(values_only=True):
+        if not row:
+            continue
+
+        assignment = row[2] if len(row) > 2 else None
+        if assignment and isinstance(assignment, str) and BRACKET_MARKER_RE.search(assignment):
+            in_bracket = True
+            pending_homes = {}
+            current_start = None
+            current_round = None
+            continue
+
+        if not in_bracket:
+            continue
+
+        round_label = _normalize_round_label(row[0])
+        start_time = normalize_time(row[1])
+        if start_time:
+            current_start = start_time
+            if round_label:
+                current_round = round_label
+            elif current_start in bracket_time_map:
+                current_round = bracket_time_map[current_start]
+            pending_homes = {}
+        elif round_label:
+            current_round = round_label
+
+        if not current_start or not current_round:
+            continue
+
+        for col_idx, court_num in OVERVIEW_COURT_COLUMNS.items():
+            if court_num in skip_courts:
+                continue
+            if col_idx >= len(row):
+                continue
+            cell = row[col_idx]
+            if cell is None or not str(cell).strip():
+                continue
+            team = resolve_team_name(str(cell).strip(), aliases)
+            if is_placeholder_team(team):
+                continue
+
+            if start_time:
+                pending_homes[court_num] = team
+            elif court_num in pending_homes:
+                games.append({
+                    "date": date,
+                    "court": f"court{court_num}",
+                    "court_display": f"Court {court_num}",
+                    "type": "bracket",
+                    "round": current_round,
+                    "home_team": pending_homes[court_num],
+                    "away_team": team,
+                    "start_time": current_start,
+                    "minutes": minutes,
+                })
+                del pending_homes[court_num]
+
+    return games
+
+
+def merge_bracket_games(parsed_games, workbook, date, skip_courts, minutes, aliases, resolve_team_name, include_placeholders=True, active_courts=None):
+    bracket_start, bracket_time_map = build_bracket_time_map(workbook, date)
+    court_nums = active_courts_for_date(date, skip_courts, active_courts)
+
+    overview_games = parse_overview_bracket_games(
+        workbook,
+        date,
+        skip_courts,
+        minutes,
+        aliases,
+        bracket_start,
+        bracket_time_map,
+        resolve_team_name,
+    )
+
+    by_slot = {}
+    for game in parsed_games:
+        court_num = int(re.search(r"(\d+)", game["court"]).group(1))
+        by_slot[game_slot_key(game["start_time"], court_num)] = game
+
+    for game in overview_games:
+        court_num = int(re.search(r"(\d+)", game["court"]).group(1))
+        by_slot[game_slot_key(game["start_time"], court_num)] = game
+
+    if include_placeholders:
+        for game in generate_bracket_placeholder_games(
+            date, court_nums, bracket_time_map, bracket_start, minutes
+        ):
+            key = game_slot_key(game["start_time"], int(re.search(r"(\d+)", game["court"]).group(1)))
+            by_slot.setdefault(key, game)
+
+    merged = list(by_slot.values())
+    merged.sort(key=lambda g: (g["date"], g["court"], g["start_time"], g["round"]))
+    return merged, bracket_start, len(overview_games), len([g for g in by_slot.values() if g["type"] == "bracket"])

--- a/tests/test_throwdown_bracket.py
+++ b/tests/test_throwdown_bracket.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src" / "scripts"))
+
+from throwdown_bracket import classify_game, lookup_bracket_round
+
+
+def test_round_robin_stays_round_robin():
+    game_type, round_label = classify_game(
+        "09:25",
+        2,
+        "13:50",
+        {"13:50": "Round 1", "14:40": "Quarters"},
+    )
+    assert game_type == "round_robin"
+    assert round_label == "Round 2"
+
+
+def test_bracket_time_maps_to_quarters():
+    game_type, round_label = classify_game(
+        "14:40",
+        11,
+        "13:50",
+        {"13:50": "Round 1", "14:40": "Quarters"},
+    )
+    assert game_type == "bracket"
+    assert round_label == "Quarters"
+
+
+def test_bracket_infers_semis_from_time():
+    game_type, round_label = classify_game(
+        "15:30",
+        12,
+        "13:50",
+        {"13:50": "Round 1", "14:40": "Quarters", "15:30": "Semis"},
+    )
+    assert game_type == "bracket"
+    assert round_label == "Semis"
+
+
+def test_lookup_fuzzy_within_slot():
+    assert lookup_bracket_round("14:41", {"14:40": "Quarters"}, "13:50") == "Quarters"


### PR DESCRIPTION
## Summary
- Adds team GoPro SD card workflow (Sister Sister folder, import/merge/split scripts, per-team schedule JSONL)
- Extends court schedules with afternoon bracket placeholder slots (TBD teams) inferred from bracket start times, so court SD cards split playoff footage alongside round robin
- Adds `fill_bracket_teams.py` to fill in matchups after seeding and rename split videos from time-based TBD filenames to team names

## Test plan
- [ ] Regenerate court JSONL and confirm 18 games per court (10 RR + 8 bracket TBD slots)
- [ ] Run `process_tournament_day.sh --dry-run` against a court folder with sample footage
- [ ] Verify bracket split filenames include start time when teams are TBD (e.g. `Bracket Quarters: Court 2: 14:40: TBD vs TBD.mp4`)
- [ ] Run `fill_bracket_teams.py --dry-run --rename` with `bracket_teams.example.json` and confirm rename mapping
- [ ] Import Sister Sister SD card and run `process_team_day.sh` for one day


Made with [Cursor](https://cursor.com)